### PR TITLE
Fix pushTransaction to use correct sender public key

### DIFF
--- a/src/main/generic/consensus/mempool/Mempool.js
+++ b/src/main/generic/consensus/mempool/Mempool.js
@@ -8,7 +8,7 @@ class Mempool extends Observable {
         this._transactions = {};
 
         // All public keys of transaction senders currently in the pool.
-        this._publicKeys = {};
+        this._senderPubKeys = {};
 
         // Listen for changes in the blockchain head to evict transactions that
         // have become invalid.
@@ -28,13 +28,13 @@ class Mempool extends Observable {
             return false;
         }
 
-        // Only allow one transaction per publicKey at a time.
+        // Only allow one transaction per senderPubKey at a time.
         // TODO This is a major limitation!
-        if (this._publicKeys[transaction.publicKey]) {
-            console.warn('Mempool rejecting transaction - duplicate public key');
+        if (this._senderPubKeys[transaction.senderPubKey]) {
+            console.warn('Mempool rejecting transaction - duplicate sender public key');
             return false;
         }
-        this._publicKeys[transaction.publicKey] = true;
+        this._senderPubKeys[transaction.senderPubKey] = true;
 
         // Transaction is valid, add it to the mempool.
         this._transactions[hash] = transaction;
@@ -105,7 +105,7 @@ class Mempool extends Observable {
             const transaction = this._transactions[hash];
             if (!await this._verifyTransactionBalance(transaction, true)) {
                 delete this._transactions[hash];
-                delete this._publicKeys[transaction.publicKey];
+                delete this._senderPubKeys[transaction.senderPubKey];
             }
         }
 


### PR DESCRIPTION
This commit changes pushTransaction() to use the correct property to get
the sender public key from a transaction. Closes #48.