### PR TITLE
Prevent implicit empty primitive creation

### DIFF
--- a/src/main/generic/consensus/block/Block.js
+++ b/src/main/generic/consensus/block/Block.js
@@ -92,7 +92,7 @@ class Block {
 /* Genesis Block */
 Block.GENESIS = new Block(
     new BlockHeader(
-        new Hash(),
+        new Hash(null),
         new Hash('Xmju8G32zjPl4m6U/ULB3Nyozs2BkVgX2k9fy5/HeEg='),
         new Hash('cJ6AyISHokEeHuTfufIqhhSS0gxHZRUMDHlKvXD4FHw='),
         BlockUtils.difficultyToCompact(1),

--- a/src/main/generic/consensus/primitive/Primitive.js
+++ b/src/main/generic/consensus/primitive/Primitive.js
@@ -1,6 +1,6 @@
 class Primitive extends Uint8Array {
     constructor(arg, length) {
-        if (!arg) {
+        if (arg === null) {
             super(length);
         } else if (typeof arg === 'string') {
             const buffer = BufferUtils.fromBase64(arg);
@@ -13,7 +13,7 @@ class Primitive extends Uint8Array {
             Primitive._enforceLength(arg, length);
             super(arg.buffer, arg.byteOffset, arg.byteLength);
         } else {
-            throw 'Primitive: Invalid argument ' + arg;
+            throw `Primitive: Invalid argument ${arg}`;
         }
     }
 

--- a/src/test/specs/generic/consensus/block/BlockHeader.spec.js
+++ b/src/test/specs/generic/consensus/block/BlockHeader.spec.js
@@ -14,7 +14,7 @@ describe('BlockHeader', () => {
          4 bytes difficulty
          8 bytes timestamp
          8 bytes nonce
-         ---------------------------- 
+         ----------------------------
          116 bytes
          */
         const blockHeader1 = new BlockHeader(prevHash, bodyHash, accountsHash, difficulty, timestamp, nonce);
@@ -36,10 +36,10 @@ describe('BlockHeader', () => {
             const test3 = new BlockHeader(true, bodyHash, accountsHash, difficulty, timestamp, nonce);
         }).toThrow('Malformed prevHash');
         expect(() => {
-            const test4 = new BlockHeader(new Address(), bodyHash, accountsHash, difficulty, timestamp, nonce);
+            const test4 = new BlockHeader(new Address(null), bodyHash, accountsHash, difficulty, timestamp, nonce);
         }).toThrow('Malformed prevHash');
         expect(() => {
-            const test5 = new BlockHeader(new Signature(), bodyHash, accountsHash, difficulty, timestamp, nonce);
+            const test5 = new BlockHeader(new Signature(null), bodyHash, accountsHash, difficulty, timestamp, nonce);
         }).toThrow('Malformed prevHash');
         expect(() => {
             const test5 = new BlockHeader(new ArrayBuffer(32), bodyHash, accountsHash, difficulty, timestamp, nonce);
@@ -57,10 +57,10 @@ describe('BlockHeader', () => {
             const test3 = new BlockHeader(prevHash, true, accountsHash, difficulty, timestamp, nonce);
         }).toThrow('Malformed bodyHash');
         expect(() => {
-            const test4 = new BlockHeader(prevHash, new Address(), accountsHash, difficulty, timestamp, nonce);
+            const test4 = new BlockHeader(prevHash, new Address(null), accountsHash, difficulty, timestamp, nonce);
         }).toThrow('Malformed bodyHash');
         expect(() => {
-            const test5 = new BlockHeader(prevHash, new Signature(), accountsHash, difficulty, timestamp, nonce);
+            const test5 = new BlockHeader(prevHash, new Signature(null), accountsHash, difficulty, timestamp, nonce);
         }).toThrow('Malformed bodyHash');
         expect(() => {
             const test5 = new BlockHeader(prevHash, new Uint8Array(32), accountsHash, difficulty, timestamp, nonce);
@@ -78,10 +78,10 @@ describe('BlockHeader', () => {
             const test3 = new BlockHeader(prevHash, bodyHash, true, difficulty, timestamp, nonce);
         }).toThrow('Malformed accountsHash');
         expect(() => {
-            const test4 = new BlockHeader(prevHash, bodyHash, new Address(), difficulty, timestamp, nonce);
+            const test4 = new BlockHeader(prevHash, bodyHash, new Address(null), difficulty, timestamp, nonce);
         }).toThrow('Malformed accountsHash');
         expect(() => {
-            const test5 = new BlockHeader(prevHash, bodyHash, new Signature(), difficulty, timestamp, nonce);
+            const test5 = new BlockHeader(prevHash, bodyHash, new Signature(null), difficulty, timestamp, nonce);
         }).toThrow('Malformed accountsHash');
         expect(() => {
             const test5 = new BlockHeader(prevHash, bodyHash, new Uint8Array(32), difficulty, timestamp, nonce);

--- a/src/test/specs/generic/consensus/mempool/Mempool.spec.js
+++ b/src/test/specs/generic/consensus/mempool/Mempool.spec.js
@@ -124,7 +124,7 @@ describe('Mempool', () => {
             // Push a bunch of transactions into the mempool
             const referenceTransactions = [];
             for (let i = 0; i < numberOfTransactions; i++) {
-                const transaction = await wallets[i].createTransaction(new Address(Dummy.address), 234, 1, 42);
+                const transaction = await wallets[i].createTransaction(new Address(Dummy.address1), 234, 1, 42);
                 const result = await mempool.pushTransaction(transaction);
                 expect(result).toBe(true);
                 referenceTransactions.push(transaction);

--- a/src/test/specs/generic/consensus/primitive/PublicKey.spec.js
+++ b/src/test/specs/generic/consensus/primitive/PublicKey.spec.js
@@ -21,14 +21,14 @@ describe('PublicKey', () => {
             const pubKey = new PublicKey(new ArrayBuffer(64));
         }).toThrow('Primitive: Invalid length');
     });
-    
+
     it('is serializable and unserializable', () => {
-        const pubKey1 = new PublicKey();
+        const pubKey1 = new PublicKey(null);
         const pubKey2 = PublicKey.unserialize(pubKey1.serialize());
 
         expect(pubKey1.equals(pubKey2)).toEqual(true);
     });
-    
+
     it('has an equals method', () => {
         const pubKey1 = new PublicKey(Dummy.publicKey1);
         const pubKey2 = new PublicKey(Dummy.publicKey2);

--- a/src/test/specs/generic/consensus/transaction/Transaction.spec.js
+++ b/src/test/specs/generic/consensus/transaction/Transaction.spec.js
@@ -54,10 +54,10 @@ describe('Transaction', () => {
             const test3 = new Transaction(true, recipientAddr, value, fee, nonce, signature);
         }).toThrow('Malformed senderPubKey');
         expect(() => {
-            const test4 = new Transaction(new Address(), recipientAddr, value, fee, nonce, signature);
+            const test4 = new Transaction(new Address(null), recipientAddr, value, fee, nonce, signature);
         }).toThrow('Malformed senderPubKey');
         expect(() => {
-            const test5 = new Transaction(new Signature(), recipientAddr, value, fee, nonce, signature);
+            const test5 = new Transaction(new Signature(null), recipientAddr, value, fee, nonce, signature);
         }).toThrow('Malformed senderPubKey');
         expect(() => {
             const test5 = new Transaction(new Uint8Array(65), recipientAddr, value, fee, nonce, signature);
@@ -78,10 +78,10 @@ describe('Transaction', () => {
             const test3 = new Transaction(senderPubKey, true, value, fee, nonce, signature);
         }).toThrow('Malformed recipientAddr');
         expect(() => {
-            const test4 = new Transaction(senderPubKey, new PublicKey(), value, fee, nonce, signature);
+            const test4 = new Transaction(senderPubKey, new PublicKey(null), value, fee, nonce, signature);
         }).toThrow('Malformed recipientAddr');
         expect(() => {
-            const test5 = new Transaction(senderPubKey, new Signature(), value, fee, nonce, signature);
+            const test5 = new Transaction(senderPubKey, new Signature(null), value, fee, nonce, signature);
         }).toThrow('Malformed recipientAddr');
         expect(() => {
             const test5 = new Transaction(senderPubKey, new Uint8Array(20), value, fee, nonce, signature);


### PR DESCRIPTION
Require the use of the null parameter to create an empty object of any
class that inherits from the Primitive Class to prevent the mistaken
creation of an empty object when a parameter that is passed to the
constructor doesn't exists (i.e. is undefined).