### PR TITLE
Block spec: check whether max size of (currently) 1MB is enforced

### DIFF
--- a/src/test/specs/generic/consensus/block/Block.spec.js
+++ b/src/test/specs/generic/consensus/block/Block.spec.js
@@ -1,6 +1,5 @@
 describe('Block', () => {
 
-
     it('must have a well defined header (116 bytes)', () => {
         expect(() => {
             const test1 = new Block(undefined, Dummy.body1);
@@ -52,5 +51,60 @@ describe('Block', () => {
 
         expect(block2.serializedSize).toBe(size);
         expect(BufferUtils.equals(block1, block2)).toBe(true);
+    });
+
+
+    it(`must not be larger than ${  Policy.BLOCK_SIZE_MAX  } bytes`, done => {
+
+        async function createBlock(numTransactions) {
+
+            const transaction = Dummy.block1.transactions[0];
+
+            // array containing `numTransactions` copies of `transaction`
+            const transactions = new Array(numTransactions).fill(transaction);
+            const body = new BlockBody(new Address(Dummy.address1),
+            transactions);
+
+            const rawGenesisHash = await Block.GENESIS.hash();
+            const genesisHash = new Hash(rawGenesisHash);
+            const rawBodyHash = await body.hash();
+            const bodyHash = new Hash(rawBodyHash);
+            const accountHash = new Hash(Dummy.hash1);
+            const compactDifficulty = BlockUtils.difficultyToCompact(1);
+            const header = new BlockHeader(genesisHash, bodyHash, accountHash,
+            compactDifficulty, 0, 0);
+
+            return new Block(header, body);
+        }
+
+        async function test() {
+            // computing the maximal number of transactions allowed
+            const transaction = Dummy.block1.transactions[0];
+            const maxTransactions = Math.floor(          // round off
+            (Policy.BLOCK_SIZE_MAX  -                    // block size limit
+            Dummy.header1.serializedSize -               // header size
+            20) /                                        // miner address size
+            transaction.serializedSize);                 // transaction size
+
+            console.log(`max transactions: ${  maxTransactions}`);
+
+            try {
+                const biggest = await createBlock(maxTransactions);
+            } catch (e) {
+                done.fail('Valid block rejected!');
+            }
+
+            try {
+                const tooBig = await createBlock(maxTransactions + 1);
+            } catch (e) {
+                console.log('Rejected invalid block.');
+                done();
+                return;
+            }
+            done.fail('Did not reject invalid block!');
+
+        }
+
+        test();
     });
 });


### PR DESCRIPTION
 ref #66

Right now, the upper limit is NOT enforced during the block creation, only check found is in Blockchain._verifyBlock