### PR TITLE
Use Math.pow instead of ** (for greater compat)

### DIFF
--- a/src/main/generic/consensus/block/BlockUtils.js
+++ b/src/main/generic/consensus/block/BlockUtils.js
@@ -1,6 +1,6 @@
 class BlockUtils {
     static compactToTarget(compact) {
-        return (compact & 0xffffff) * (2 ** (8 * ((compact >> 24) - 3)));
+        return (compact & 0xffffff) * Math.pow(2, (8 * ((compact >> 24) - 3)));
     }
 
     static targetToCompact(target) {


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.

## What's in this pull request?

Fixes issues with `**` operator in Microsoft Edge.
