### PR TITLE
Remove assumption of github.com account & ssh pub key assoc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Check out our betanet [Browser Miner](https://nimiq.com/betanet)
 
 ## Quickstart 
 
-1. Clone this repository `git clone git@github.com:nimiq-network/core.git`.
+1. Clone this repository `git clone https://github.com/nimiq-network/core`.
 2. Run `npm install` or `yarn`
 3. Run `./node_modules/.bin/gulp build`
 4. Open `clients/browser/index.html` in your browser to access the Browser Client.


### PR DESCRIPTION
As best practices, public repositories should avoid the assumption that participants have 
1) a github.com account 
2) an ssh key associated to their account 
3) willing to reveal to a third party who they are (i.e. by association to a github.com account)

git clone git@github.com method makes these assumptions whereas
git clone https://github.com/nimi.... does not.

## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts. Confirmation: ____

#### This fixes issue #___.

## What's in this pull request?

>...
