### PR TITLE
Delay checkPeerCount method, so that we can update our addresses

### DIFF
--- a/src/main/generic/network/Network.js
+++ b/src/main/generic/network/Network.js
@@ -199,7 +199,8 @@ class Network extends Observable {
 
         // Call _checkPeerCount() here in case the peer doesn't send us any (new)
         // addresses to keep on connecting.
-        this._checkPeerCount();
+        // Add a delay before calling it to allow RTC peer addresses to be sent to us.
+        setTimeout(() => this._checkPeerCount(), Network.ADDRESS_UPDATE_DELAY);
     }
 
 
@@ -457,6 +458,7 @@ Network.PEER_COUNT_DESIRED = 6;
 Network.PEER_COUNT_RELAY = 4;
 Network.CONNECTING_COUNT_MAX = 2;
 Network.SIGNAL_TTL_INITIAL = 3;
+Network.ADDRESS_UPDATE_DELAY = 1000; // 1 second
 Class.register(Network);
 
 class SignalStore {


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.

## What's in this pull request?

This adds a delay between receiving a new connection and checking whether we need more connections. The delay should allow us to get new RTC peer addresses we can connect to.
This might reduce the initial bias towards our seed nodes.