### PR TITLE
Fix README.md URL in ISSUE_TEMPLATE.md

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,7 @@
 ## New issue checklist
 <!-- Before submitting this issue, make sure you have done the following -->
 
-- [ ] I have read all of the [`README`](../README.md) 
+- [ ] I have read all of the [`README`](https://github.com/nimiq-network/core/blob/master/README.md) 
 - [ ] I have searched [existing issues](https://github.com/nimiq-network/core/issues?q=is%3Aissue+sort%3Acreated-desc) and **this is not a duplicate**.
 
 ### General information


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts. Confirmation: ____

## What's in this pull request?

I've noticed that the link for `README.md` in `ISSUE_TEMPLATE.md` doesn't work as expected. I've replaced it with the respective absolute path.
