### PR TITLE
Singleton PersistentAccountsTreeStore

### DIFF
--- a/src/main/generic/consensus/account/tree/AccountsTreeStore.js
+++ b/src/main/generic/consensus/account/tree/AccountsTreeStore.js
@@ -13,9 +13,17 @@ class AccountsTreeStore {
 }
 Class.register(AccountsTreeStore);
 
+
+let _instance = null;
+
 class PersistentAccountsTreeStore extends ObjectDB {
+
     constructor() {
-        super('accounts', AccountsTreeNode);
+        if (_instance) {
+            return _instance;
+        }
+        _instance = super('accounts', AccountsTreeNode);
+        return _instance;
     }
 
     async getRootKey() {

--- a/src/main/generic/consensus/account/tree/AccountsTreeStore.js
+++ b/src/main/generic/consensus/account/tree/AccountsTreeStore.js
@@ -1,6 +1,6 @@
 class AccountsTreeStore {
     static getPersistent() {
-        return new PersistentAccountsTreeStore();
+        return PersistentAccountsTreeStore.get();
     }
 
     static createVolatile() {
@@ -13,17 +13,21 @@ class AccountsTreeStore {
 }
 Class.register(AccountsTreeStore);
 
-
-let _instance = null;
-
+/**
+ * Singleton implementation of persistent accounts tree store to avoid locking issues with
+ * the underlying database.
+ */
 class PersistentAccountsTreeStore extends ObjectDB {
 
-    constructor() {
-        if (_instance) {
-            return _instance;
+    static get() {
+        if (!PersistentAccountsTreeStore._instance) {
+            PersistentAccountsTreeStore._instance = new PersistentAccountsTreeStore();
         }
-        _instance = super('accounts', AccountsTreeNode);
-        return _instance;
+        return PersistentAccountsTreeStore._instance;
+    }
+
+    constructor() {
+        super('accounts', AccountsTreeNode);
     }
 
     async getRootKey() {
@@ -45,6 +49,7 @@ class PersistentAccountsTreeStore extends ObjectDB {
         return tx;
     }
 }
+PersistentAccountsTreeStore._instance = null;
 
 class VolatileAccountsTreeStore {
     constructor() {


### PR DESCRIPTION
#### This fixes issue #161 .

## What's in this pull request?

A simple singleton implementation for ```PersistentAccountsTreeStore```. Without a singleton, multiple calls to ```getPersistent``` return different handles to the database that result in locking issues, as explained in #161. 

Note that, even though the AccountsTree specs state that persistent tests can be activated as soon as #161 is closed, we can not do this at the moment because they fail for several reasons (e.g., #188 ). Hence, solving those problems is not part of this PR, here we just implement the needed functionality to run the tests. As soon as the problems are fixed, the persistent tests can be safely added. 
