### PR TITLE
Use same levelDB connection if instantiated multiple times

### DIFF
--- a/src/main/platform/nodejs/database/TypedDB.js
+++ b/src/main/platform/nodejs/database/TypedDB.js
@@ -1,11 +1,14 @@
-var levelup = require('levelup');
+const levelup = require('levelup');
 
 class TypedDB {
     constructor(tableName, type) {
         if (!type || !type.unserialize) throw 'NodeJS TypedDB requires type with .unserialize()';
-        this._db = levelup('./database/' + tableName, {
-            keyEncoding: 'ascii'
-        });
+        if (!TypedDB._dbConnections[tableName]) {
+            TypedDB._dbConnections[tableName] = levelup(`./database/${tableName}`, {
+                keyEncoding: 'ascii'
+            });
+        }
+        this._db = TypedDB._dbConnections[tableName];
         this._type = type;
     }
 
@@ -62,6 +65,7 @@ class TypedDB {
         return new TypedDBTransaction(this);
     }
 }
+TypedDB._dbConnections = {};
 Class.register(TypedDB);
 
 class NativeDBTransaction extends Observable {


### PR DESCRIPTION
This fixes issue #161 in alternative way to #191.

Instead of putting PersistentAccountsTreeStore into a singleton, we handle the problem at its root and do not create multiple LevelDB connections for the same file.