### PR TITLE
Display HEX hashes in alpha cockpit (#204)

### DIFF
--- a/clients/browser/index.html
+++ b/clients/browser/index.html
@@ -318,7 +318,7 @@
             this._wltBalance = document.querySelector('#wltBalance');
             this._wltNonce = document.querySelector('#wltNonce');
 
-            this._wltAddress.innerText = $.wallet.address.toHex().toUpperCase();
+            this._wltAddress.innerText = $.wallet.address.toHex();
 
             $.accounts.getBalance($.wallet.address).then(function(balance) {
                 this._balanceChanged(balance);
@@ -415,33 +415,39 @@
             this._bcTotalWork.innerText = $.blockchain.totalWork;
             this._bcHeight.innerText = $.blockchain.height;
             $.blockchain.accountsHash().then(function(accountsHash) {
-                this._bcAccountsHash.innerText = accountsHash;
+                this._bcAccountsHash.innerText = accountsHash.toHex();
             }.bind(this));
 
-            this._hdHash.innerText = $.blockchain.headHash;
-            this._hdPrevHash.innerText = $.blockchain.head.prevHash;
-            this._hdAccountsHash.innerText = $.blockchain.head.accountsHash;
+            this._hdHash.innerText = $.blockchain.headHash.toHex();
+            this._hdPrevHash.innerText = $.blockchain.head.prevHash.toHex();
+            this._hdAccountsHash.innerText = $.blockchain.head.accountsHash.toHex();
             this._hdDifficulty.innerText = $.blockchain.head.difficulty;
             this._hdTimestamp.innerText = new Date($.blockchain.head.timestamp * 1000);
             this._hdNonce.innerText = $.blockchain.head.nonce;
 
             var el = document.createElement('div');
             var date = new Date(head.timestamp * 1000);
-            var html = `<div><b>${date}</b> hash=<hash>${$.blockchain.headHash.toBase64()}</hash>, `
-                + `miner=<hash>${head.minerAddr}</hash>, difficulty=${head.difficulty}</div>`;
+            var html = `<div><b>${date}</b> hash=<hash>${$.blockchain.headHash.toHex()}</hash>, `
+                + `miner=<hash>${head.minerAddr.toHex()}</hash>, difficulty=${head.difficulty}</div>`;
+
+            var txPromises = [];
 
             for (var tx of head.transactions) {
-                var senderAddr = 'TODO'; //await tx.getSenderAddr();
-                var value = Nimiq.Policy.satoshisToCoins(tx.value).toFixed(4);
-                var fee = Nimiq.Policy.satoshisToCoins(tx.fee).toFixed(4);
-                html += `<div>&nbsp;-&gt; from=<hash>${senderAddr}</hash>, to=<hash>${tx.recipientAddr}</hash>, value=${value}, fee=${fee}, nonce=${tx.nonce}</div>`;
+                txPromises.push(tx.getSenderAddr().then(function(senderAddr) {
+                    var value = Nimiq.Policy.satoshisToCoins(tx.value).toFixed(4);
+                    var fee = Nimiq.Policy.satoshisToCoins(tx.fee).toFixed(4);
+                    return `<div>&nbsp;-&gt; from=<hash>${senderAddr.toHex()}</hash>, to=<hash>${tx.recipientAddr.toHex()}</hash>, value=${value}, fee=${fee}, nonce=${tx.nonce}</div>`;
+                }));
             }
-            el.innerHTML = html;
 
-            if (this._blockHistory.childNodes.length > 24) {
-                this._blockHistory.removeChild(this._blockHistory.firstChild);
-            }
-            this._blockHistory.appendChild(el);
+            Promise.all(txPromises).then(function(results) {
+                el.innerHTML = html + results.join('');
+
+                if (this._blockHistory.childNodes.length > 24) {
+                    this._blockHistory.removeChild(this._blockHistory.firstChild);
+                }
+                this._blockHistory.appendChild(el);
+            }.bind(this));
         }
 
         _toggleMining() {
@@ -508,12 +514,13 @@
             }
 
             for (var tx of txs) {
-                var el = document.createElement('div');
-                var senderAddr = 'TODO'; //await tx.getSenderAddr();
-                var value = Nimiq.Policy.satoshisToCoins(tx.value).toFixed(4);
-                var fee = Nimiq.Policy.satoshisToCoins(tx.fee).toFixed(4);
-                el.innerHTML = `from=<hash>${senderAddr}</hash>, to=<hash>${tx.recipientAddr}</hash>, value=${value}, fee=${fee}, nonce=${tx.nonce}`;
-                this._mplTransactions.appendChild(el);
+                tx.getSenderAddr().then(function(senderAddr) {
+                    var el = document.createElement('div');
+                    var value = Nimiq.Policy.satoshisToCoins(tx.value).toFixed(4);
+                    var fee = Nimiq.Policy.satoshisToCoins(tx.fee).toFixed(4);
+                    el.innerHTML = `from=<hash>${senderAddr.toHex()}</hash>, to=<hash>${tx.recipientAddr.toHex()}</hash>, value=${value}, fee=${fee}, nonce=${tx.nonce}`;
+                    this._mplTransactions.appendChild(el);
+                }.bind(this));
             }
         }
     }

--- a/clients/browser/style.css
+++ b/clients/browser/style.css
@@ -140,6 +140,8 @@ input.error {
 
 hash {
     font-size: 12px;
+    font-family: monospace;
+    text-transform: uppercase;
 }
 
 .f-left {
@@ -333,6 +335,11 @@ hash {
 
 .wallet-address, .wallet-balance, .wallet-nonce {
     /*display:none;*/
+}
+
+.wallet-address span {
+    font-family: monospace;
+    text-transform: uppercase;
 }
 
 .copy-wallet-seed {


### PR DESCRIPTION
* Display HEX hashes everywhere
* Refactor async await to use the Promise API
* Remove redundant new Promise
* Enable `toHex` conversion only on the view, not internally
* Fix not-actually-changed-files
* Fix orphan from earlier commits

## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

## What's in this pull request?

Display HEX hashes in the alpha cockpit
