### PR TITLE
Show past average block time in full client

### DIFF
--- a/clients/browser/full.html
+++ b/clients/browser/full.html
@@ -532,7 +532,7 @@
         _showAverageBlockTime() {
             const headBlock = $.blockchain.head;
 
-            $.blockchain.getBlockAt(headBlock.height - 100).then(function(tailBlock) {
+            $.blockchain.getBlockAt(headBlock.height - Nimiq.Policy.DIFFICULTY_BLOCK_WINDOW).then(function(tailBlock) {
                 const averageBlockTime = (headBlock.timestamp - tailBlock.timestamp) / (headBlock.height - tailBlock.height);
 
                 this._bcAverageBlockTime.innerText = averageBlockTime + " s";

--- a/clients/browser/full.html
+++ b/clients/browser/full.html
@@ -111,6 +111,10 @@
                 <span id="bcHeight"></span>
             </div>
             <div class="info-block">
+                <strong>Average Block Time</strong>
+                <span id="bcAverageBlockTime"></span>
+            </div>
+            <div class="info-block">
                 <strong>Accounts Hash</strong>
                 <hash id="bcAccountsHash"></hash>
             </div>
@@ -250,6 +254,8 @@
             this._bcTotalWork = document.querySelector('#bcTotalWork');
             /** @type {HTMLElement} */
             this._bcHeight = document.querySelector('#bcHeight');
+            /** @type {HTMLElement} */
+            this._bcAverageBlockTime = document.querySelector('#bcAverageBlockTime');
             /** @type {HTMLElement} */
             this._bcAccountsHash = document.querySelector('#bcAccountsHash');
 
@@ -398,6 +404,7 @@
             this._bcTotalDifficulty.innerText = $.blockchain.totalDifficulty;
             this._bcTotalWork.innerText = $.blockchain.totalWork;
             this._bcHeight.innerText = $.blockchain.height;
+            this._showAverageBlockTime();
             $.blockchain.accountsHash().then(function(accountsHash) {
                 this._bcAccountsHash.innerText = accountsHash.toBase64();
             }.bind(this));
@@ -520,6 +527,15 @@
                     this._mplTransactions.appendChild(el);
                 }.bind(this));
             }.bind(this));
+        }
+
+        async _showAverageBlockTime() {
+            const headBlock = $.blockchain.head;
+            const tailBlock = await $.blockchain.getBlockAt(headBlock.height - 100);
+
+            const averageBlockTime = (headBlock.timestamp - tailBlock.timestamp) / (headBlock.height - tailBlock.height);
+
+            this._bcAverageBlockTime.innerText = averageBlockTime + " s";
         }
     }
 

--- a/clients/browser/full.html
+++ b/clients/browser/full.html
@@ -529,13 +529,14 @@
             }.bind(this));
         }
 
-        async _showAverageBlockTime() {
+        _showAverageBlockTime() {
             const headBlock = $.blockchain.head;
-            const tailBlock = await $.blockchain.getBlockAt(headBlock.height - 100);
 
-            const averageBlockTime = (headBlock.timestamp - tailBlock.timestamp) / (headBlock.height - tailBlock.height);
+            $.blockchain.getBlockAt(headBlock.height - 100).then(function(tailBlock) {
+                const averageBlockTime = (headBlock.timestamp - tailBlock.timestamp) / (headBlock.height - tailBlock.height);
 
-            this._bcAverageBlockTime.innerText = averageBlockTime + " s";
+                this._bcAverageBlockTime.innerText = averageBlockTime + " s";
+            }.bind(this));
         }
     }
 

--- a/clients/browser/full.html
+++ b/clients/browser/full.html
@@ -530,12 +530,12 @@
         }
 
         _showAverageBlockTime() {
-            const headBlock = $.blockchain.head;
+            const headBlock  = $.blockchain.head;
+            const tailHeight = Math.max(headBlock.height - Nimiq.Policy.DIFFICULTY_BLOCK_WINDOW, 1);
 
-            $.blockchain.getBlockAt(headBlock.height - Nimiq.Policy.DIFFICULTY_BLOCK_WINDOW).then(function(tailBlock) {
+            $.blockchain.getBlockAt(tailHeight).then(function(tailBlock) {
                 const averageBlockTime = (headBlock.timestamp - tailBlock.timestamp) / (headBlock.height - tailBlock.height);
-
-                this._bcAverageBlockTime.innerText = averageBlockTime + " s";
+                this._bcAverageBlockTime.innerText = averageBlockTime + ' s';
             }.bind(this));
         }
     }


### PR DESCRIPTION
## What's in this pull request?
Add a field in the BLOCKCHAIN info box of the full client that shows the average block time of the last 100 blocks.
