### PR TITLE
Extend difficulty and work calculation to dense suffix of chain proof prefix

### DIFF
--- a/src/main/generic/consensus/base/blockchain/BlockChain.js
+++ b/src/main/generic/consensus/base/blockchain/BlockChain.js
@@ -137,6 +137,27 @@ class BlockChain {
     }
 
     /**
+     * @returns {Promise.<Array.<Block>>}
+     */
+    async denseSuffix() {
+        // Compute the dense suffix.
+        const denseSuffix = [this.head];
+        let denseSuffixHead = this.head;
+        for (let i = this.length - 2; i >= 0; i--) {
+            const block = this.blocks[i];
+            const hash = await block.hash();
+            if (!hash.equals(denseSuffixHead.prevHash)) {
+                break;
+            }
+
+            denseSuffix.push(block);
+            denseSuffixHead = block;
+        }
+        denseSuffix.reverse();
+        return denseSuffix;
+    }
+
+    /**
      * @returns {Promise.<boolean>}
      */
     async isAnchored() {

--- a/src/main/generic/consensus/base/blockchain/ChainProof.js
+++ b/src/main/generic/consensus/base/blockchain/ChainProof.js
@@ -65,20 +65,9 @@ class ChainProof {
      */
     async _verifyDifficulty() {
         // Extract the dense suffix of the prefix.
-        const denseSuffix = [this.prefix.head.header];
-        let head = this.prefix.head;
-        for (let i = this.prefix.length - 2; i >= 0; i--) {
-            const block = this.prefix.blocks[i];
-            const hash = await block.hash();
-            if (!hash.equals(head.prevHash)) {
-                break;
-            }
-
-            denseSuffix.push(block.header);
-            head = block;
-        }
-        denseSuffix.reverse();
-
+        let denseSuffix = await this.prefix.denseSuffix();
+        /** Array.<BlockHeader> */
+        denseSuffix = denseSuffix.map(block => block.header);
         /** Array.<BlockHeader> */
         const denseChain = denseSuffix.concat(this.suffix.headers);
 

--- a/src/main/generic/consensus/light/PartialLightChain.js
+++ b/src/main/generic/consensus/light/PartialLightChain.js
@@ -143,55 +143,29 @@ class PartialLightChain extends LightChain {
             // Delete our current chain.
             await this._store.truncate();
 
-            // Compute the dense suffix of the prefix.
-            // Then use it to compute totalWork and totalDifficulty.
-            const denseSuffix = [proof.prefix.head.header];
-            let denseSuffixStart = proof.prefix.length - 1;
-            let denseSuffixHead = proof.prefix.head;
-            for (let i = proof.prefix.length - 2; i >= 0; i--) {
-                const block = proof.prefix.blocks[i];
-                const hash = await block.hash();
-                if (!hash.equals(denseSuffixHead.prevHash)) {
-                    break;
-                }
-
-                --denseSuffixStart;
-                denseSuffix.push(block.header);
-                denseSuffixHead = block;
-            }
-            denseSuffix.reverse();
-
-            // Compute totalDifficulty and totalWork for each block of the dense chain.
-            let totalDifficulty = 0, totalWork = 0;
-            const totalDifficulties = [], totalWorks = [];
-            for (let i = 0; i < denseSuffix.length; i++) {
-                totalDifficulty += denseSuffix[i].difficulty;
-                totalDifficulties[denseSuffixStart + i] = totalDifficulty;
-
-                totalWork += BlockUtils.realDifficulty(await denseSuffix[i].pow());
-                totalWorks[denseSuffixStart + i] = totalWork;
-            }
-
-            // Set the prefix head as the new chain head.
-            // TODO use the tail end of the dense suffix of the prefix instead.
-            this._headHash = headHash;
-            this._mainChain = new ChainData(head, totalDifficulties[totalDifficulties.length - 1], totalWorks[totalWorks.length - 1], true);
-            await this._store.putChainData(headHash, this._mainChain);
+            /** @type {Array.<Block>} */
+            const denseSuffix = await proof.prefix.denseSuffix();
 
             // Put all other prefix blocks in the store as well (so they can be retrieved via getBlock()/getBlockAt()),
             // but don't allow blocks to be appended to them by setting totalDifficulty = -1;
-            // Only in the dense suffix of the prefix we can calculate the difficulties.
-            for (let i = 0; i < proof.prefix.length - 1; i++) {
+            for (let i = 0; i < proof.prefix.length - denseSuffix.length; i++) {
                 const block = proof.prefix.blocks[i];
                 const hash = await block.hash();
-                let totalDifficulty = -1;
-                let totalWork = -1;
-                if (totalDifficulties[i]) {
-                    totalDifficulty = totalDifficulties[i];
-                    totalWork = totalWorks[i];
-                }
-                const data = new ChainData(block, /*totalDifficulty*/ totalDifficulty, /*totalWork*/ totalWork, true);
+                const data = new ChainData(block, /*totalDifficulty*/ -1, /*totalWork*/ -1, true);
                 await this._store.putChainData(hash, data);
+            }
+
+            // Set the tail end of the dense suffix of the prefix as the new chain head.
+            const tailEnd = denseSuffix[0];
+            this._headHash = await tailEnd.hash();
+            this._mainChain = new ChainData(tailEnd, tailEnd.difficulty, BlockUtils.realDifficulty(await tailEnd.pow()), true);
+            await this._store.putChainData(this._headHash, this._mainChain);
+
+            // Only in the dense suffix of the prefix we can calculate the difficulties.
+            for (let i = 1; i < denseSuffix.length; i++) {
+                const block = denseSuffix[i];
+                const result = await this._pushBlock(block); // eslint-disable-line no-await-in-loop
+                Assert.that(result >= 0);
             }
         }
 

--- a/src/main/generic/consensus/nano/NanoChain.js
+++ b/src/main/generic/consensus/nano/NanoChain.js
@@ -143,18 +143,54 @@ class NanoChain extends BaseChain {
             // Delete our current chain.
             await this._store.truncate();
 
+            // Compute the dense suffix of the prefix.
+            // Then use it to compute totalWork and totalDifficulty.
+            const denseSuffix = [proof.prefix.head.header];
+            let denseSuffixStart = proof.prefix.length - 1;
+            let denseSuffixHead = proof.prefix.head;
+            for (let i = proof.prefix.length - 2; i >= 0; i--) {
+                const block = proof.prefix.blocks[i];
+                const hash = await block.hash();
+                if (!hash.equals(denseSuffixHead.prevHash)) {
+                    break;
+                }
+
+                --denseSuffixStart;
+                denseSuffix.push(block.header);
+                denseSuffixHead = block;
+            }
+            denseSuffix.reverse();
+
+            // Compute totalDifficulty and totalWork for each block of the dense chain.
+            let totalDifficulty = 0, totalWork = 0;
+            const totalDifficulties = [], totalWorks = [];
+            for (let i = 0; i < denseSuffix.length; i++) {
+                totalDifficulty += denseSuffix[i].difficulty;
+                totalDifficulties[denseSuffixStart + i] = totalDifficulty;
+
+                totalWork += BlockUtils.realDifficulty(await denseSuffix[i].pow());
+                totalWorks[denseSuffixStart + i] = totalWork;
+            }
+
             // Set the prefix head as the new chain head.
             // TODO use the tail end of the dense suffix of the prefix instead.
             this._headHash = headHash;
-            this._mainChain = new ChainData(head, head.difficulty, BlockUtils.realDifficulty(await head.pow()), true);
+            this._mainChain = new ChainData(head, totalDifficulties[totalDifficulties.length - 1], totalWorks[totalWorks.length - 1], true);
             await this._store.putChainData(headHash, this._mainChain);
 
             // Put all other prefix blocks in the store as well (so they can be retrieved via getBlock()/getBlockAt()),
             // but don't allow blocks to be appended to them by setting totalDifficulty = -1;
+            // Only in the dense suffix of the prefix we can calculate the difficulties.
             for (let i = 0; i < proof.prefix.length - 1; i++) {
                 const block = proof.prefix.blocks[i];
                 const hash = await block.hash();
-                const data = new ChainData(block, /*totalDifficulty*/ -1, /*totalWork*/ -1, true);
+                let totalDifficulty = -1;
+                let totalWork = -1;
+                if (totalDifficulties[i]) {
+                    totalDifficulty = totalDifficulties[i];
+                    totalWork = totalWorks[i];
+                }
+                const data = new ChainData(block, /*totalDifficulty*/ totalDifficulty, /*totalWork*/ totalWork, true);
                 await this._store.putChainData(hash, data);
             }
         }


### PR DESCRIPTION
Compute totalDifficulty and totalWork in the dense suffix of the chain proof prefix.
Verification is still done when verifying the chain proof.

This change then allows to verify (parts of) the suffix.