### PR TITLE
fix for Issue https://github.com/nimiq-network/core/issues/247 .

### DIFF
--- a/src/native/nimiq_native.c
+++ b/src/native/nimiq_native.c
@@ -1,7 +1,12 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
-#include <arpa/inet.h>
+#if defined(_WIN32)
+    #include <winsock2.h>
+    #pragma comment(lib, "Ws2_32.lib")
+#else
+    #include <arpa/inet.h>
+#endif
 #include "nimiq_native.h"
 
 static inline uint16_t bswap_16(uint16_t x) {


### PR DESCRIPTION
nodejs client windows compiling compatibility.  similar pattern was used in ed25519.h .

## Pull request checklist

- [x ] All tests pass. Demo project builds and runs.
- [ x] I have resolved any merge conflicts. Confirmation: ____

#### This fixes issue #247.

## What's in this pull request?
nimiq_native.c include change to use winsock2.h on windows instead of arpa/inet.h.