### PR TITLE
Fix syncing of full clients if the peer does not have any new inv vectors for us.

### DIFF
--- a/src/main/generic/consensus/BaseConsensusAgent.js
+++ b/src/main/generic/consensus/BaseConsensusAgent.js
@@ -203,6 +203,8 @@ class BaseConsensusAgent extends Observable {
             else {
                 this._timers.setTimeout('inv', () => this._requestData(), BaseConsensusAgent.REQUEST_THROTTLE);
             }
+        } else {
+            this._onNoUnknownObjects();
         }
     }
 
@@ -467,6 +469,13 @@ class BaseConsensusAgent extends Observable {
         } else {
             this._onAllObjectsReceived();
         }
+    }
+
+    /**
+     * @returns {void}
+     * @protected
+     */
+    _onNoUnknownObjects() {
     }
 
     /**

--- a/src/main/generic/consensus/full/FullConsensusAgent.js
+++ b/src/main/generic/consensus/full/FullConsensusAgent.js
@@ -223,6 +223,18 @@ class FullConsensusAgent extends BaseConsensusAgent {
     }
 
     /**
+     * @returns {void}
+     * @protected
+     * @override
+     */
+    _onNoUnknownObjects() {
+        // The peer does not have any new inv vectors for us.
+        if (this._syncing) {
+            this.syncBlockchain();
+        }
+    }
+
+    /**
      * @param {HeaderMessage} msg
      * @return {Promise.<void>}
      * @protected


### PR DESCRIPTION
Introduce callback when no new inv vectors are sent by a peer.
Call syncBlockchain in this case in the FullConsensusAgent.
Closes #255.