### PR TITLE
Closes #261: Country code in wallet address should not be case sensitive

### DIFF
--- a/src/main/generic/consensus/base/account/Address.js
+++ b/src/main/generic/consensus/base/account/Address.js
@@ -75,7 +75,7 @@ class Address extends Primitive {
      */
     static fromUserFriendlyAddress(str) {
         str = str.replace(/ /g, '');
-        if (str.substr(0, 2) !== Address.CCODE) {
+        if (str.substr(0, 2).toUpperCase() !== Address.CCODE) {
             throw new Error('Invalid Address: Wrong country code', 201);
         }
         if (str.length !== 36) {


### PR DESCRIPTION
#### This fixes issue #261.

## What's in this pull request?
* Compare wallet address country code insensitively.
