### PR TITLE
Make code compatible with Babel

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -176,7 +176,9 @@ const sources = {
 const dependencies = ['./node_modules/jungle-db/dist/web.js']; // external dependencies
 
 const babel_config = {
-    plugins: ['transform-runtime', 'transform-es2015-modules-commonjs'],
+    plugins: [['transform-runtime', {
+        'polyfill': false
+    }], 'transform-es2015-modules-commonjs'],
     presets: ['es2016', 'es2017']
 };
 

--- a/src/main/generic/consensus/light/LightConsensusAgent.js
+++ b/src/main/generic/consensus/light/LightConsensusAgent.js
@@ -110,7 +110,7 @@ class LightConsensusAgent extends FullConsensusAgent {
         // Case 3: We are are syncing.
         if (this._syncing && !this._busy) {
             if (this._catchup) {
-                await super.syncBlockchain();
+                await FullConsensusAgent.prototype.syncBlockchain.call(this);
             } else {
                 // Initialize partial chain on first call.
                 if (!this._partialChain) {
@@ -480,13 +480,13 @@ class LightConsensusAgent extends FullConsensusAgent {
                 && (!this._partialChain || this._partialChain.state !== PartialLightChain.State.PROVE_BLOCKS)) {
                 this._onMainChain = false;
                 await this._initChainProofSync();
-                this.syncBlockchain();
+                this.syncBlockchain().catch(e => Log.e(LightConsensusAgent, e));
                 return;
             } else {
                 this._onMainChain = true;
             }
 
-            super._onKnownBlockAnnounced(hash, block);
+            FullConsensusAgent.prototype._onKnownBlockAnnounced.call(this, hash, block);
         }
     }
 

--- a/src/main/generic/miner/MinerWorkerImpl.js
+++ b/src/main/generic/miner/MinerWorkerImpl.js
@@ -1,6 +1,12 @@
 class MinerWorkerImpl extends IWorker.Stub(MinerWorker) {
+    constructor() {
+        super();
+        // FIXME: This is needed for Babel to work correctly. Can be removed as soon as we updated to Babel v7.
+        this._superInit = super.init;
+    }
+
     async init(name) {
-        await super.init(name);
+        await this._superInit.call(this, name);
 
         if (await this.importWasm('worker-wasm.wasm')) {
             await this.importScript('worker-wasm.js');

--- a/src/main/generic/miner/MinerWorkerPool.js
+++ b/src/main/generic/miner/MinerWorkerPool.js
@@ -21,6 +21,9 @@ class MinerWorkerPool extends IWorker.Pool(MinerWorker) {
         /** @type {number} */
         this._cycleWait = 100;
 
+        // FIXME: This is needed for Babel to work correctly. Can be removed as soon as we updated to Babel v7.
+        this._superUpdateToSize = super._updateToSize;
+
         if (PlatformUtils.isNodeJs()) {
             const nimiq_node = require(`${__dirname}/nimiq_node`);
             /**
@@ -131,7 +134,7 @@ class MinerWorkerPool extends IWorker.Pool(MinerWorker) {
 
     async _updateToSize() {
         if (!PlatformUtils.isNodeJs()) {
-            await super._updateToSize();
+            await this._superUpdateToSize.call(this);
         }
 
         while (this._miningEnabled && this._activeNonces.length < this.poolSize) {

--- a/src/main/generic/utils/crypto/CryptoWorkerImpl.js
+++ b/src/main/generic/utils/crypto/CryptoWorkerImpl.js
@@ -1,6 +1,12 @@
 class CryptoWorkerImpl extends IWorker.Stub(CryptoWorker) {
+    constructor() {
+        super();
+        // FIXME: This is needed for Babel to work correctly. Can be removed as soon as we updated to Babel v7.
+        this._superInit = super.init;
+    }
+
     async init(name) {
-        await super.init(name);
+        await this._superInit.call(this, name);
 
         if (await this.importWasm('worker-wasm.wasm')) {
             await this.importScript('worker-wasm.js');


### PR DESCRIPTION
At some locations, we still used `super` calls in `async` functions, which is currently not supported by Babel. Babel fixes this issue in v7, which is still a pre-release.