### PR TITLE
Performance improvements NIPoPoW prover

### DIFF
--- a/src/main/generic/consensus/base/blockchain/BaseChain.js
+++ b/src/main/generic/consensus/base/blockchain/BaseChain.js
@@ -80,10 +80,10 @@ class BaseChain extends IBlockchain {
 
 
 
-    /* NIPoPoW functions */
+    /* NIPoPoW Prover functions */
 
     /**
-     * @returns {Promise.<?ChainProof>}
+     * @returns {Promise.<ChainProof>}
      * @protected
      */
     async _getChainProof() {
@@ -99,7 +99,7 @@ class BaseChain extends IBlockchain {
      * @param {number} m
      * @param {number} k
      * @param {number} delta
-     * @returns {Promise.<?ChainProof>}
+     * @returns {Promise.<ChainProof>}
      * @private
      */
     async _prove(m, k, delta) {
@@ -116,15 +116,12 @@ class BaseChain extends IBlockchain {
         for (let depth = maxDepth; depth >= 0; depth--) {
             // alpha = C[:-k]{B:}|^mu
             const alpha = await this._getSuperChain(depth, head, startHeight); // eslint-disable-line no-await-in-loop
-            if (!alpha) {
-                return null;
-            }
 
             // pi = pi (union) alpha
             prefix = BlockChain.merge(prefix, alpha);
 
             // if good_(delta,m)(C, alpha, mu) then
-            if (BaseChain.isGoodSuperChain(alpha, depth, m, delta)) {
+            if (BaseChain._isGoodSuperChain(alpha, depth, m, delta)) {
                 Assert.that(alpha.length >= m, `Good superchain expected to be at least ${m} long`);
                 Log.v(BaseChain, `Found good superchain at depth ${depth} with length ${alpha.length} (#${startHeight} - #${head.height})`);
                 // B <- alpha[-m]
@@ -139,12 +136,11 @@ class BaseChain extends IBlockchain {
         return new ChainProof(prefix, suffix);
     }
 
-
     /**
      * @param {number} depth
      * @param {Block} [head]
      * @param {number} [tailHeight]
-     * @returns {Promise.<?BlockChain>}
+     * @returns {Promise.<BlockChain>}
      * @private
      */
     async _getSuperChain(depth, head = this.head, tailHeight = 1) {
@@ -164,8 +160,10 @@ class BaseChain extends IBlockchain {
         while (j < references.length && head.height > tailHeight) {
             head = await this.getBlock(references[j]); // eslint-disable-line no-await-in-loop
             if (!head) {
-                Log.w(BaseChain, `Failed to find block ${references[j]} while constructing SuperChain`);
-                return null;
+                // This can happen in the light/nano client if chain superquality is harmed.
+                // Return a best-effort chain in this case.
+                Log.w(BaseChain, `Failed to find block ${references[j]} while constructing SuperChain at depth ${depth} - returning truncated chain`);
+                break;
             }
             blocks.push(head.toLight());
 
@@ -187,7 +185,7 @@ class BaseChain extends IBlockchain {
      * @param {number} delta
      * @returns {boolean}
      */
-    static isGoodSuperChain(superchain, depth, m, delta) {
+    static _isGoodSuperChain(superchain, depth, m, delta) {
         // TODO multilevel quality
         return BaseChain._hasSuperQuality(superchain, depth, m, delta);
     }
@@ -242,6 +240,156 @@ class BaseChain extends IBlockchain {
             head = await this.getBlock(head.prevHash); // eslint-disable-line no-await-in-loop
         }
         return new HeaderChain(headers.reverse());
+    }
+
+    /**
+     * @param {ChainProof} proof
+     * @param {BlockHeader} header
+     * @param {boolean} [failOnBadness]
+     * @returns {Promise.<ChainProof>}
+     * @protected
+     */
+    async _extendChainProof(proof, header, failOnBadness = true) {
+        // Append new header to proof suffix.
+        const suffix = proof.suffix.headers.slice();
+        suffix.push(header);
+
+        // If the suffix is not long enough (short chain), we're done.
+        const prefix = proof.prefix.blocks.slice();
+        if (suffix.length <= Policy.K) {
+            return new ChainProof(new BlockChain(prefix), new HeaderChain(suffix));
+        }
+
+        // Cut the tail off the suffix.
+        const suffixTail = suffix.shift();
+
+        // Construct light block out of the old suffix tail.
+        const interlink = await proof.prefix.head.getNextInterlink(suffixTail.target);
+        const prefixHead = new Block(suffixTail, interlink);
+
+        // Append old suffix tail block to prefix.
+        prefix.push(prefixHead);
+
+        // Extract layered superchains from prefix. Make a copy because we are going to change the chains array.
+        const chains = (await proof.getSuperChains()).slice();
+
+        // Append new prefix head to chains.
+        const target = BlockUtils.hashToTarget(await prefixHead.pow());
+        const depth = BlockUtils.getTargetDepth(target);
+        for (let i = depth; i >= 0; i--) {
+            // Append block. Don't modify the chain, create a copy.
+            if (!chains[i]) {
+                chains[i] = new BlockChain([prefixHead]);
+            } else {
+                chains[i] = new BlockChain([...chains[i].blocks, prefixHead]);
+            }
+        }
+
+        // If the new header isn't a superblock, we're done.
+        if (depth - BlockUtils.getTargetDepth(prefixHead.target) <= 0) {
+            return new ChainProof(new BlockChain(prefix), new HeaderChain(suffix), chains);
+        }
+
+        // Prune unnecessary blocks if the chain is good.
+        // Try to extend proof if the chain is bad.
+        const deletedBlockHeights = new Set();
+        for (let i = depth; i >= 0; i--) {
+            const superchain = chains[i];
+            if (superchain.length < Policy.M) {
+                continue;
+            }
+
+            if (BaseChain._isGoodSuperChain(superchain, i, Policy.M, Policy.DELTA)) {
+                // Remove all blocks in lower chains up to (including) superchain[-m].
+                const referenceBlock = superchain.blocks[superchain.length - Policy.M];
+                for (let j = i - 1; j >= 0; j--) {
+                    let numBlocksToDelete = 0;
+                    let candidateBlock = chains[j].blocks[numBlocksToDelete];
+                    while (candidateBlock.height <= referenceBlock.height) {
+                        const candidateTarget = BlockUtils.hashToTarget(await candidateBlock.pow());
+                        const candidateDepth = BlockUtils.getTargetDepth(candidateTarget);
+                        if (candidateDepth === j && candidateBlock.height > 1) {
+                            deletedBlockHeights.add(candidateBlock.height);
+                        }
+
+                        numBlocksToDelete++;
+                        candidateBlock = chains[j].blocks[numBlocksToDelete];
+                    }
+
+                    if (numBlocksToDelete > 0) {
+                        // Don't modify the chain, create a copy.
+                        chains[j] = new BlockChain(chains[j].blocks.slice(numBlocksToDelete));
+                    }
+                }
+            } else {
+                Log.w(BaseChain, `Chain quality badness detected at depth ${i}`);
+                // TODO extend superchains at lower levels
+                if (failOnBadness) {
+                    return null;
+                }
+            }
+        }
+
+        // Remove all deleted blocks from prefix.
+        const newPrefix = new BlockChain(prefix.filter(block => !deletedBlockHeights.has(block.height)));
+
+        // Return the extended proof.
+        return new ChainProof(newPrefix, new HeaderChain(suffix), chains);
+    }
+
+
+    /* NiPoPoW Verifier functions */
+
+    /**
+     * @param {ChainProof} proof1
+     * @param {ChainProof} proof2
+     * @param {number} m
+     * @returns {boolean}
+     */
+    static async isBetterProof(proof1, proof2, m) {
+        const lca = BlockChain.lowestCommonAncestor(proof1.prefix, proof2.prefix);
+        const score1 = await NanoChain._getProofScore(proof1.prefix, lca, m);
+        const score2 = await NanoChain._getProofScore(proof2.prefix, lca, m);
+        return score1 === score2
+            ? proof1.suffix.totalDifficulty() >= proof2.suffix.totalDifficulty()
+            : score1 > score2;
+    }
+
+    /**
+     *
+     * @param {BlockChain} chain
+     * @param {Block} lca
+     * @param {number} m
+     * @returns {Promise.<number>}
+     * @protected
+     */
+    static async _getProofScore(chain, lca, m) {
+        const counts = [];
+        for (const block of chain.blocks) {
+            if (block.height < lca.height) {
+                continue;
+            }
+
+            const target = BlockUtils.hashToTarget(await block.pow()); // eslint-disable-line no-await-in-loop
+            const depth = BlockUtils.getTargetDepth(target);
+            counts[depth] = counts[depth] ? counts[depth] + 1 : 1;
+        }
+
+        let sum = 0;
+        let depth;
+        for (depth = counts.length - 1; sum < m && depth >= 0; depth--) {
+            sum += counts[depth] ? counts[depth] : 0;
+        }
+
+        let maxScore = Math.pow(2, depth + 1) * sum;
+        let length = sum;
+        for (let i = depth; i >= 0; i--) {
+            length += counts[i] ? counts[i] : 0;
+            const score = Math.pow(2, i) * length;
+            maxScore = Math.max(maxScore, score);
+        }
+
+        return maxScore;
     }
 }
 Class.register(BaseChain);

--- a/src/main/generic/consensus/light/LightChain.js
+++ b/src/main/generic/consensus/light/LightChain.js
@@ -32,8 +32,6 @@ class LightChain extends FullChain {
      */
     constructor(store, accounts) {
         super(store, accounts);
-
-        this._proof = null;
     }
 
     /**
@@ -41,30 +39,17 @@ class LightChain extends FullChain {
      * @protected
      */
     async _init() {
-        // FIXME: this is a workaround as Babel doesn't understands await super().
+        // FIXME: this is a workaround as Babel doesn't understand await super().
         await FullChain.prototype._init.call(this);
         if (!this._proof) {
-            this._proof = await this.getChainProof();
+            this._proof = await this._getChainProof();
         }
         return this;
     }
 
-    /**
-     * @returns {Promise.<?ChainProof>}
-     * @override
-     */
-    async getChainProof() {
-        const proof = await this._getChainProof();
-        if (!proof) {
-            // If we cannot construct a chain proof, superquality of the chain is harmed.
-            // Return the last known proof.
-            return this._proof;
-        }
-        return proof;
-    }
-
     async partialChain() {
-        const partialChain = new PartialLightChain(this._store, this._accounts, this._proof);
+        const proof = await this.getChainProof();
+        const partialChain = new PartialLightChain(this._store, this._accounts, proof);
         partialChain.on('committed', async (proof, headHash, mainChain) => {
             this._proof = proof;
             this._headHash = headHash;


### PR DESCRIPTION
Improve performance of the NIPoPoW prover by caching the ChainProof and extending it when new blocks are pushed. The proof is lazily recomputed when chain quality is harmed or a rebranch occurred.