### PR TITLE
fix: dev: Fix verify to work with partial trees

### DIFF
--- a/src/main/generic/consensus/base/account/tree/AccountsProof.js
+++ b/src/main/generic/consensus/base/account/tree/AccountsProof.js
@@ -60,17 +60,19 @@ class AccountsProof {
         for (const node of this._nodes) {
             // If node is a branch node, validate its children.
             if (node.isBranch()) {
-                // Get the number of children
-                const numberOfChildren = node.numberOfChildren();
-                for (let i = 0; i < numberOfChildren; i++) {
-                    const child = children.pop();
-                    const hash = await child.hash(); // eslint-disable-line no-await-in-loop
-                    // If the child is not valid, return false.
-                    if (!node.getChildHash(child.prefix).equals(hash) || node.getChild(child.prefix) !== child.prefix) {
-                        return false;
+                let child;
+                while (child = children.pop()) { // eslint-disable-line no-cond-assign
+                    if (child.isChildOf(node)) {
+                        const hash = await child.hash(); // eslint-disable-line no-await-in-loop
+                        // If the child is not valid, return false.
+                        if (!node.getChildHash(child.prefix).equals(hash) || node.getChild(child.prefix) !== child.prefix) {
+                            return false;
+                        }
+                        this._index.put(hash, child);
+                    } else {
+                        children.push(child);
+                        break;
                     }
-
-                    this._index.put(hash, child);
                 }
             }
 

--- a/src/main/generic/consensus/base/account/tree/AccountsTreeNode.js
+++ b/src/main/generic/consensus/base/account/tree/AccountsTreeNode.js
@@ -275,14 +275,13 @@ class AccountsTreeNode {
     }
 
     /**
-     * Test if this node is a child of some other node
-     * @param {AccountsTreeNode} possibleParent
+     * Tests if this node is a child of some other node.
+     * @param {AccountsTreeNode} parent
      * @returns {boolean}
      */
-    isChildOf(possibleParent) {
-        return (possibleParent.getChildren()).includes(this._prefix);
+    isChildOf(parent) {
+        return parent.getChildren() && parent.getChildren().includes(this._prefix);
     }
-
 
     /**
      * @returns {boolean}

--- a/src/main/generic/consensus/base/account/tree/AccountsTreeNode.js
+++ b/src/main/generic/consensus/base/account/tree/AccountsTreeNode.js
@@ -38,6 +38,7 @@ class AccountsTreeNode {
      */
     constructor(type, prefix = '', arg, arg2 = []) {
         this._type = type;
+        /** @type {string} */
         this._prefix = prefix;
         if (this.isBranch()) {
             /** @type {Array.<string>} */
@@ -274,25 +275,14 @@ class AccountsTreeNode {
     }
 
     /**
-     * Returns the number of children this node has
-     * @param {boolean} [includeBranchNodes]
-     * @returns {number}
+     * Test if this node is a child of some other node
+     * @param {AccountsTreeNode} possibleParent
+     * @returns {boolean}
      */
-    numberOfChildren(includeBranchNodes = true) {
-        let childrenToCount;
-
-        if (includeBranchNodes) {
-            childrenToCount = this._childrenSuffixes || [];
-        } else {
-            // Only terminal nodes have suffixes that equal Address.HEX_SIZE (40 hex numbers) when added to the
-            // parent's prefix.
-            childrenToCount = this._childrenSuffixes.filter(suffix => (this._prefix + suffix).length === Address.HEX_SIZE);
-        }
-
-        // The children array contains undefined values for non existing children.
-        // Only count existing ones.
-        return childrenToCount.reduce((count, child) => count + !!child, 0);
+    isChildOf(possibleParent) {
+        return (possibleParent.getChildren()).includes(this._prefix);
     }
+
 
     /**
      * @returns {boolean}

--- a/src/test/specs/generic/consensus/base/account/tree/AccountsProof.spec.js
+++ b/src/test/specs/generic/consensus/base/account/tree/AccountsProof.spec.js
@@ -1,21 +1,27 @@
 describe('AccountsProof', () => {
-    let nodes, account4;
+    let sizesArray, accountsArray, prefixesArray, testNodesArray;
 
     /*
-     *            R1
-     *            |
-     *            B1
-     *          / |  \
-     *         T1 B2 T2
-     *           / \
-     *          T3 T4
+     * We're going to construct three proofs based on this tree:
+     *
+     *      R1
+     *      |
+     *      B1
+     *    / |  \
+     *   T1 B2 T2
+     *     / \
+     *    T3 T4
+     *
+     * The first proof proves the 4 terminal nodes (T1, T2, T3 and T4)
+     * The second proof proves the 2 leftmost terminal nodes (T1 and T3)
+     * The third proof just proves T4
      */
     beforeEach(function (done) {
         (async function () {
             const account1 = new BasicAccount(new Balance(25, 3));
             const account2 = new BasicAccount(new Balance(1, 925));
             const account3 = new BasicAccount(new Balance(1322, 532));
-            account4 = new BasicAccount(new Balance(93, 11));
+            const account4 = new BasicAccount(new Balance(93, 11));
 
             const t1 = AccountsTreeNode.terminalNode('0011111111111111111111111111111111111111', account1);
             const t1Hash = await t1.hash();
@@ -37,7 +43,14 @@ describe('AccountsProof', () => {
 
             const r1 = AccountsTreeNode.branchNode('', ['00'], [b1Hash]);
 
-            nodes = [t1, t3, t4, b2, t2, b1, r1];
+            const nodes1 = [t1, t3, t4, b2, t2, b1, r1];
+            const nodes2 = [t1, t3, b2, b1, r1];
+            const nodes3 = [t4, b2, b1, r1];
+
+            sizesArray = [7, 5, 4];
+            accountsArray = [account2, account3, account4];
+            prefixesArray = [t2.prefix.split(''), t3.prefix.split(''), t4.prefix.split('')];
+            testNodesArray = [nodes1, nodes2, nodes3];
         })().then(done, done.fail);
     });
 
@@ -62,127 +75,151 @@ describe('AccountsProof', () => {
     });
 
     it('is serializable and unserializable', () => {
-        const accountsProof1 = new AccountsProof(nodes);
-        const accountsProof2 = AccountsProof.unserialize(accountsProof1.serialize());
-        const nodesArray = accountsProof2.nodes;
-        const length2 = accountsProof2.length;
+        for (nodes of testNodesArray) {
+            const accountsProof1 = new AccountsProof(nodes);
+            const accountsProof2 = AccountsProof.unserialize(accountsProof1.serialize());
+            const nodesArray = accountsProof2.nodes;
+            const length2 = accountsProof2.length;
 
-        expect(length2).toBe(7);
-        expect(accountsProof1.length === length2).toBe(true);
-        for (let i = 0; i < length2; i++) {
-            expect(nodesArray[i].equals(nodes[i])).toBe(true);
+            expect(length2).toBe(sizesArray.shift());
+            expect(accountsProof1.length === length2).toBe(true);
+            for (let j = 0; j < length2; j++) {
+                expect(nodesArray[j].equals(nodes[j])).toBe(true);
+            }
         }
     });
 
     it('must not return an account before verify() has been run', (done) => {
-        const accountsProof1 = new AccountsProof(nodes);
-        const address = TestUtils.raw2address('0033333333333333333333333333333333333333'.split(''));
         (async () => {
-            expect( function(){ accountsProof1.getAccount(address);} ).toThrowError(Error, 'AccountsProof must be verified before retrieving accounts. Call verify() first.');
+            for (nodes of testNodesArray) {
+                const accountsProof1 = new AccountsProof(nodes);
+                const address = TestUtils.raw2address(prefixesArray.shift());
+
+                expect(function () { accountsProof1.getAccount(address); }).toThrowError(Error, 'AccountsProof must be verified before retrieving accounts. Call verify() first.');
+            }
         })().then(done, done.fail);
     });
 
     it('must be able to correctly return an account after verify() has been run', (done) => {
-        const accountsProof1 = new AccountsProof(nodes);
-        const address = TestUtils.raw2address('0022222222222222222222222222222222222222'.split(''));
         (async () => {
-            const verified = await accountsProof1.verify();
-            expect(verified).toBe(true);
-            const account = accountsProof1.getAccount(address);
-            expect(account.equals(account4)).toBe(true);
+            for (nodes of testNodesArray) {
+                const accountsProof1 = new AccountsProof(nodes);
+                const address = TestUtils.raw2address(prefixesArray.shift());
+
+                const verified = await accountsProof1.verify();
+                expect(verified).toBe(true);
+                const account = accountsProof1.getAccount(address);
+                expect(account.equals(accountsArray.shift())).toBe(true);
+            }
         })().then(done, done.fail);
     });
 
     it('must not verify successfully neither return an account if it contains a tainted AccountTreeNode', (done) => {
-        const t1 = nodes[0];
-        t1._account = account4;
-        nodes[0] = t1;
-        const accountsProof1 = new AccountsProof(nodes);
-
-        // Since hashes of AccountTreeNodes are cached locally, we need to simulate
-        // sending the node through the network by serializing and unserializing it
-        // for this to work
-        const accountsProof2 = AccountsProof.unserialize(accountsProof1.serialize());
-
-        const address = TestUtils.raw2address('0022222222222222222222222222222222222222'.split(''));
         (async () => {
-            const verified = await accountsProof2.verify();
-            expect(verified).toBe(false);
-            expect( function(){ accountsProof2.getAccount(address);} ).toThrowError(Error, 'Requested address not part of AccountsProof');
+            for (nodes of testNodesArray) {
+                const node = nodes[0]; // get the first node
+                node._account = accountsArray[0]; // change its account to a different one
+                nodes[0] = node; // set it back
+                const accountsProof1 = new AccountsProof(nodes);
+                const address = TestUtils.raw2address(prefixesArray.shift());
+
+                // Since hashes of AccountTreeNodes are cached locally, we need to simulate
+                // sending the node through the network by serializing and unserializing it
+                // for this to work
+                const accountsProof2 = AccountsProof.unserialize(accountsProof1.serialize());
+
+                const verified = await accountsProof2.verify();
+                expect(verified).toBe(false);
+                expect(function () { accountsProof2.getAccount(address); }).toThrowError(Error, 'Requested address not part of AccountsProof');
+            }
         })().then(done, done.fail);
     });
 
     it('must not verify successfully if it contains any node before the Root Node', (done) => {
-        const fakeAccount = new BasicAccount(new Balance(42, 31337));
-        const fakeTreeNode = AccountsTreeNode.terminalNode('0023333222222222222222222222222222222222', fakeAccount);
-        nodes.push(fakeTreeNode);
-        const accountsProof1 = new AccountsProof(nodes);
-
-        // Since hashes of AccountTreeNodes are cached locally, we need to simulate
-        // sending the node through the network by serializing and unserializing it
-        // for this to work
-        const accountsProof2 = AccountsProof.unserialize(accountsProof1.serialize());
-
         (async () => {
-            const verified = await accountsProof2.verify();
-            expect(verified).toBe(false);
+            for (nodes of testNodesArray) {
+                const fakeAccount = new BasicAccount(new Balance(42, 31337));
+                const fakeTreeNode = AccountsTreeNode.terminalNode('0020000000000000345000000000000000000000', fakeAccount);
+                nodes.push(fakeTreeNode);
+                const accountsProof1 = new AccountsProof(nodes);
+
+                // Since hashes of AccountTreeNodes are cached locally, we need to simulate
+                // sending the node through the network by serializing and unserializing it
+                // for this to work
+                const accountsProof2 = AccountsProof.unserialize(accountsProof1.serialize());
+
+                const verified = await accountsProof2.verify();
+                expect(verified).toBe(false);
+            }
         })().then(done, done.fail);
     });
 
     it('must not verify successfully if it contains a node that is not part of the Tree at the end', (done) => {
-        const fakeAccount = new BasicAccount(new Balance(42, 31337));
-        const fakeTreeNode = AccountsTreeNode.terminalNode('0023333222222222222222222222222222222222', fakeAccount);
-        nodes.unshift(fakeTreeNode);
-        const accountsProof1 = new AccountsProof(nodes);
-
-        // Since hashes of AccountTreeNodes are cached locally, we need to simulate
-        // sending the node through the network by serializing and unserializing it
-        // for this to work
-        const accountsProof2 = AccountsProof.unserialize(accountsProof1.serialize());
-
         (async () => {
-            const verified = await accountsProof2.verify();
-            expect(verified).toBe(false);
+            for (nodes of testNodesArray) {
+                const fakeAccount = new BasicAccount(new Balance(42, 31337));
+                const fakeTreeNode = AccountsTreeNode.terminalNode('0020000000000000345000000000000000000000', fakeAccount);
+                nodes.unshift(fakeTreeNode);
+                const accountsProof1 = new AccountsProof(nodes);
+
+                // Since hashes of AccountTreeNodes are cached locally, we need to simulate
+                // sending the node through the network by serializing and unserializing it
+                // for this to work
+                const accountsProof2 = AccountsProof.unserialize(accountsProof1.serialize());
+
+                const verified = await accountsProof2.verify();
+                expect(verified).toBe(false);
+            }
         })().then(done, done.fail);
     });
 
-    it('must not verify successfully neither return an account if it contains a node that is not part of the Tree', (done) => {
-        const fakeAccount = new BasicAccount(new Balance(42, 31337));
-        const fakeTreeNode = AccountsTreeNode.terminalNode('0023333222222222222222222222222222222222', fakeAccount);
-        nodes.splice(4,0, fakeTreeNode);
-        const accountsProof1 = new AccountsProof(nodes);
-
-        // Since hashes of AccountTreeNodes are cached locally, we need to simulate
-        // sending the node through the network by serializing and unserializing it
-        // for this to work
-        const accountsProof2 = AccountsProof.unserialize(accountsProof1.serialize());
-        const address = TestUtils.raw2address('0023333222222222222222222222222222222222'.split(''));
+    it('must not verify successfully neither return the account if it contains a node that is not part of the Tree', (done) => {
         (async () => {
-            const verified = await accountsProof2.verify();
-            expect(verified).toBe(false);
-            expect( function(){ accountsProof2.getAccount(address);} ).toThrowError(Error, 'Requested address not part of AccountsProof');
+            for (nodes of testNodesArray) {
+                const fakeAccount = new BasicAccount(new Balance(42, 31337));
+                const fakeTreeNode = AccountsTreeNode.terminalNode('0020000000000000345000000000000000000000', fakeAccount);
+                nodes.splice(2, 0, fakeTreeNode);
+                const accountsProof1 = new AccountsProof(nodes);
+                const address = TestUtils.raw2address('0020000000000000345000000000000000000000'.split(''));
+
+                // Since hashes of AccountTreeNodes are cached locally, we need to simulate
+                // sending the node through the network by serializing and unserializing it
+                // for this to work
+                const accountsProof2 = AccountsProof.unserialize(accountsProof1.serialize());
+
+                const verified = await accountsProof2.verify();
+                expect(verified).toBe(false);
+                expect(function () { accountsProof2.getAccount(address); }).toThrowError(Error, 'Requested address not part of AccountsProof');
+            }
         })().then(done, done.fail);
     });
 
     it('must return the correct root hash', (done) => {
-        const accountsProof1 = new AccountsProof(nodes);
-        const rootHash = new Hash(BufferUtils.fromBase64('UfAZwaXYoNdWgxTjefgWClEY/X2J2HzHL5MUq1qfRNI='));
         (async () => {
-            const hash = await accountsProof1.root();
-            expect(hash.equals(rootHash)).toBe(true);
+            for (nodes of testNodesArray) {
+                const accountsProof1 = new AccountsProof(nodes);
+                const rootHash = new Hash(BufferUtils.fromBase64('UfAZwaXYoNdWgxTjefgWClEY/X2J2HzHL5MUq1qfRNI='));
+
+                const hash = await accountsProof1.root();
+                expect(hash.equals(rootHash)).toBe(true);
+            }
         })().then(done, done.fail);
     });
 
     it('must return the correct length', () => {
-        const accountsProof1 = new AccountsProof(nodes);
-        expect(accountsProof1.length).toBe(7);
+        for (nodes of testNodesArray) {
+            const accountsProof1 = new AccountsProof(nodes);
+            expect(accountsProof1.length).toBe(sizesArray.shift());
+        }
     });
 
     it('must return the correct nodes array', () => {
-        const accountsProof1 = new AccountsProof(nodes);
-        const hashesArray = accountsProof1.nodes;
-        for (let i = 0; i < nodes.length; i++) {
-            expect(hashesArray[i].equals(nodes[i])).toBe(true);
+        for (nodes of testNodesArray) {
+            const accountsProof1 = new AccountsProof(nodes);
+            const hashesArray = accountsProof1.nodes;
+            for (let i = 0; i < nodes.length; i++) {
+                expect(hashesArray[i].equals(nodes[i])).toBe(true);
+            }
         }
     });
 });


### PR DESCRIPTION
The last update to `AccountsProof` introduced a bug that prevented proofs with only partial trees (i.e.  proofs that contain branch nodes without all of their children) from verifying correctly.

This PR fixes that and also improves the test case to cover two more valid scenarios.