### PR TITLE
Dynamic block reward

### DIFF
--- a/src/main/generic/consensus/base/account/Accounts.js
+++ b/src/main/generic/consensus/base/account/Accounts.js
@@ -221,7 +221,7 @@ class Accounts extends Observable {
 
         // "Coinbase transaction"
         const coinbaseSender = new Address(new Uint8Array(Address.SERIALIZED_SIZE));
-        const coinbaseTransaction = new ExtendedTransaction(coinbaseSender, Account.Type.BASIC, body.minerAddr, Account.Type.BASIC, txFees + Policy.BLOCK_REWARD, 0, 0, new Uint8Array(0));
+        const coinbaseTransaction = new ExtendedTransaction(coinbaseSender, Account.Type.BASIC, body.minerAddr, Account.Type.BASIC, txFees + Policy.blockRewardAt(blockHeight), 0, 0, new Uint8Array(0));
 
         const recipientAccount = await this.get(body.minerAddr, undefined, tree) || BasicAccount.INITIAL;
         await tree.putBatch(body.minerAddr, recipientAccount.withIncomingTransaction(coinbaseTransaction, blockHeight, revert));

--- a/src/test/specs/generic/Policy.spec.js
+++ b/src/test/specs/generic/Policy.spec.js
@@ -47,11 +47,39 @@ describe('Policy', () => {
     });
 
     it('correctly calculates LunaNet reward', () => {
-        let currentSupply = Policy.INITIAL_SUPPLY;
-
         expect(Policy.blockRewardAt(0)).toBe(Policy.coinsToSatoshis(5), 'Wrong initial reward.');
         expect(Policy.blockRewardAt(Policy.EMISSION_CURVE_START - 1)).toBe(Policy.coinsToSatoshis(5), 'Wrong reward before curve.');
         const expectedReward = Policy._blockRewardAt(Policy.EMISSION_CURVE_START * Policy.coinsToSatoshis(5), Policy.EMISSION_CURVE_START);
         expect(Policy.blockRewardAt(Policy.EMISSION_CURVE_START)).toBe(expectedReward, 'Wrong reward at curve start.');
+    });
+
+    it('correctly calculates supply', () => {
+        expect(Policy.supplyAfter(-1)).toBe(Policy.INITIAL_SUPPLY, 'Wrong initial supply (block -1).');
+        expect(Policy.supplyAfter(0)).toBe(Policy.INITIAL_SUPPLY + Policy.blockRewardAt(0), 'Wrong initial supply (block 0).');
+
+        for (let block = 0; block < Policy._supplyCacheInterval * 10; block += Policy._supplyCacheInterval) {
+            /* FIXME change for main net */
+            // expect(Policy.supplyAfter(block-1)).toBe(Policy._supplyAfter(Policy.INITIAL_SUPPLY, block-1), `Wrong supply for block ${block-1}.`);
+            // expect(Policy.supplyAfter(block)).toBe(Policy._supplyAfter(Policy.INITIAL_SUPPLY, block), `Wrong supply for block ${block}.`);
+            // expect(Policy.supplyAfter(block+1)).toBe(Policy._supplyAfter(Policy.INITIAL_SUPPLY, block+1), `Wrong supply for block ${block+1}.`);
+            
+            if (block - 1 < Policy.EMISSION_CURVE_START) {
+                expect(Policy.supplyAfter(block-1)).toBe(block * Policy.coinsToSatoshis(5), `Wrong supply for block ${block-1}.`);
+            } else {
+                expect(Policy.supplyAfter(block-1)).toBe(Policy._supplyAfter(Policy.INITIAL_SUPPLY + (Policy.EMISSION_CURVE_START * Policy.coinsToSatoshis(5)), block-1-Policy.EMISSION_CURVE_START), `Wrong supply for block ${block-1}.`);
+            }
+
+            if (block < Policy.EMISSION_CURVE_START) {
+                expect(Policy.supplyAfter(block)).toBe((block+1) * Policy.coinsToSatoshis(5), `Wrong supply for block ${block}.`);
+            } else {
+                expect(Policy.supplyAfter(block)).toBe(Policy._supplyAfter(Policy.INITIAL_SUPPLY + (Policy.EMISSION_CURVE_START * Policy.coinsToSatoshis(5)), block-Policy.EMISSION_CURVE_START), `Wrong supply for block ${block}.`);
+            }
+
+            if (block + 1 < Policy.EMISSION_CURVE_START) {
+                expect(Policy.supplyAfter(block+1)).toBe((block+2) * Policy.coinsToSatoshis(5), `Wrong supply for block ${block+1}.`);
+            } else {
+                expect(Policy.supplyAfter(block+1)).toBe(Policy._supplyAfter(Policy.INITIAL_SUPPLY + (Policy.EMISSION_CURVE_START * Policy.coinsToSatoshis(5)), block+1-Policy.EMISSION_CURVE_START), `Wrong supply for block ${block+1}.`);
+            }
+        }
     });
 });

--- a/src/test/specs/generic/Policy.spec.js
+++ b/src/test/specs/generic/Policy.spec.js
@@ -1,0 +1,57 @@
+describe('Policy', () => {
+    it('correctly calculates the block reward and supply', () => {
+        let currentSupply = Policy.INITIAL_SUPPLY;
+
+        for (let block = 0; block < 1000; ++block) {
+            const remaining = Policy.TOTAL_SUPPLY - currentSupply;
+            const remainder = remaining % Policy.EMISSION_SPEED;
+            let reward = (remaining-remainder) / Policy.EMISSION_SPEED;
+            if (block >= Policy.EMISSION_TAIL_START && remaining >= Policy.EMISSION_TAIL_REWARD) {
+                reward = Policy.EMISSION_TAIL_REWARD;
+            }
+
+            expect(Policy._blockRewardAt(currentSupply, block)).toBe(reward, 'Wrong reward.');
+            expect(Policy._supplyAfter(Policy.INITIAL_SUPPLY, block-1)).toBe(currentSupply, 'Wrong supply.');
+            currentSupply += reward;
+        }
+    });
+
+    it('correctly computes initial supply', () => {
+        // FIXME: replace initialSupply by Policy.INITIAL_SUPPLY for main net
+        const initialSupply = Policy.coinsToSatoshis(25e5);
+
+        expect(Policy._supplyAfter(initialSupply, -1)).toBe(initialSupply, 'Wrong supply.');
+    });
+
+    it('reaches total supply after ~100 years', () => {
+        // FIXME: replace initialSupply by Policy.INITIAL_SUPPLY for main net
+        const initialSupply = Policy.coinsToSatoshis(25e5);
+
+        // Should reach 21mio NIM at block 52893521.
+        const block = 101*365*24*60*60 / Policy.BLOCK_TIME; // 101 years
+        const supply = Policy._supplyAfter(initialSupply, block-1);
+        expect(supply).toBe(Policy.TOTAL_SUPPLY, 'Wrong supply.');
+        expect(Policy._blockRewardAt(supply, block)).toBe(0, 'Wrong reward.');
+    });
+
+    it('correctly switches to tail emission', () => {
+        // FIXME: replace initialSupply by Policy.INITIAL_SUPPLY for main net
+        const initialSupply = Policy.coinsToSatoshis(25e5);
+
+        // Should reach 21mio NIM at block 52893521.
+        const block = Policy.EMISSION_TAIL_START;
+        const supply = Policy._supplyAfter(initialSupply, block-2);
+        const previousReward = Policy._blockRewardAt(supply, block-1);
+        expect(previousReward > Policy.EMISSION_TAIL_REWARD).toBe(true, 'Wrong reward before starting block.');
+        expect(Policy._blockRewardAt(supply + previousReward, block)).toBe(Policy.EMISSION_TAIL_REWARD, 'Wrong reward at starting block.');
+    });
+
+    it('correctly calculates LunaNet reward', () => {
+        let currentSupply = Policy.INITIAL_SUPPLY;
+
+        expect(Policy.blockRewardAt(0)).toBe(Policy.coinsToSatoshis(5), 'Wrong initial reward.');
+        expect(Policy.blockRewardAt(Policy.EMISSION_CURVE_START - 1)).toBe(Policy.coinsToSatoshis(5), 'Wrong reward before curve.');
+        const expectedReward = Policy._blockRewardAt(Policy.EMISSION_CURVE_START * Policy.coinsToSatoshis(5), Policy.EMISSION_CURVE_START);
+        expect(Policy.blockRewardAt(Policy.EMISSION_CURVE_START)).toBe(expectedReward, 'Wrong reward at curve start.');
+    });
+});

--- a/src/test/specs/generic/consensus/base/account/Accounts.spec.js
+++ b/src/test/specs/generic/consensus/base/account/Accounts.spec.js
@@ -111,7 +111,7 @@ describe('Accounts', () => {
 
             // now: expect user2 to have received the transaction fees and block reward
             balance = (await testBlockchain.accounts.get(user2.address, Account.Type.BASIC)).balance;
-            expect(balance).toBe(Policy.BLOCK_REWARD + fee1 + fee2);
+            expect(balance).toBe(Policy.blockRewardAt(block.height) + fee1 + fee2);
 
         })().then(done, done.fail);
     });
@@ -144,7 +144,7 @@ describe('Accounts', () => {
                 const balance1 = (await accounts.get(user1.address, Account.Type.BASIC)).balance;
                 const balance3 = (await accounts.get(user3.address, Account.Type.BASIC)).balance;
                 const balance4 = (await accounts.get(user4.address, Account.Type.BASIC)).balance;
-                expect(balance1).toBe(Policy.BLOCK_REWARD);
+                expect(balance1).toBe(Policy.blockRewardAt(block.height));
                 expect(balance3).toBe(0);
                 expect(balance4).toBe(0);
                 done();
@@ -165,8 +165,8 @@ describe('Accounts', () => {
             const treeTx = await accounts._tree.transaction();
             // create users, raise their balance, create transaction
             for (let i = 1; i < numTransactions; i++) {
-                await accounts._addBalance(treeTx, users[0].address, Policy.BLOCK_REWARD); //eslint-disable-line no-await-in-loop
-                transactionPromises.push(TestBlockchain.createTransaction(users[0].publicKey, users[1].address, Policy.BLOCK_REWARD, 0, nonce++, users[0].privateKey));
+                await accounts._addBalance(treeTx, users[0].address, Policy.coinsToSatoshis(5)); //eslint-disable-line no-await-in-loop
+                transactionPromises.push(TestBlockchain.createTransaction(users[0].publicKey, users[1].address, Policy.coinsToSatoshis(5), 0, nonce++, users[0].privateKey));
             }
             const transactions = await Promise.all(transactionPromises);
             transactions.sort((a, b) => a.compareBlockOrder(b));
@@ -187,7 +187,7 @@ describe('Accounts', () => {
             const accounts = testBlockchain.accounts;
 
             // sender balance not enough (amount + fee > block reward)
-            const transaction = await TestBlockchain.createTransaction(user1.publicKey, user2.address, Policy.BLOCK_REWARD, 1, 0, user1.privateKey);
+            const transaction = await TestBlockchain.createTransaction(user1.publicKey, user2.address, Policy.coinsToSatoshis(5), 1, 0, user1.privateKey);
             const block = await testBlockchain.createBlock({
                 transactions: [transaction],
                 minerAddr: user3.address


### PR DESCRIPTION
Implements a dynamic block reward scheme with the following properties:

- **Total Supply:** 21 million NIM
- **Total Supply reached:** after 100 years
- **Initial Reward:** ~5 NIM (4.41074371)
- The reward gradually decreases with the block height, approximately halving every 4 years.
- Starting from block #48696986 (after approximately 92 years), the reward changes from a gradually decreasing curve to a constant reward of 4000 satoshi for the next ~7 years. The previous reward at block #48696985 was 4002 satoshi.