### PR TITLE
Add regular statistic output to node miner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /clients/nodejs/node_modules
 /clients/nodejs/database
 /clients/nodejs/full-consensus
+/clients/nodejs/light-consensus
 /clients/nodejs/wallet
 /clients/nodejs/localhost.*
 /dist/nimiq*

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To run a NodeJs Client you will need a **publicly routable IP**, **Domain** and 
 
 ```bash
 cd clients/nodejs/
-node index.js --host <hostname> --port <port> --key <privkey> --cert <certificate> [--miner[=<threads>]]
+node index.js --host <hostname> --port <port> --key <privkey> --cert <certificate> [--miner[=<threads>]] [--statistics[=<interval>]]
 ```
 
 | Argument        | Description           |
@@ -49,6 +49,7 @@ node index.js --host <hostname> --port <port> --key <privkey> --cert <certificat
 | **_cert_** | SSL certificate of your Domain.       |
 | **_wallet-seed_** | Your wallet seed (optional)        |
 | **_miner_** | The number of threads to start for mining (optional) |
+| **_statistics_** | The interval in seconds to output miner statistics (optional, default: 10) |
 
 
 ### Build your own Browser client

--- a/clients/nodejs/index.js
+++ b/clients/nodejs/index.js
@@ -2,13 +2,14 @@ const Nimiq = require('../../dist/node.js');
 const argv = require('minimist')(process.argv.slice(2));
 
 if (!argv.host || !argv.port || !argv.key || !argv.cert) {
-    console.log('Usage: node index.js --host=<hostname> --port=<port> --key=<ssl-key> --cert=<ssl-cert> [--wallet-seed=<wallet-seed>] [--miner[=<thread-num>[:<throttle-after>[:<throttle-wait>]]]] [--passive] [--log=LEVEL] [--log-tag=TAG[:LEVEL]]');
+    console.log('Usage: node index.js --host=<hostname> --port=<port> --key=<ssl-key> --cert=<ssl-cert> [--wallet-seed=<wallet-seed>] [--miner[=<thread-num>[:<throttle-after>[:<throttle-wait>]]]] [--statistics[=<interval>]] [--passive] [--log=LEVEL] [--log-tag=TAG[:LEVEL]]');
     process.exit();
 }
 
 const host = argv.host;
 const port = parseInt(argv.port);
 const minerOptions = argv.miner;
+const statisticsOptions = argv.statistics;
 const passive = argv.passive;
 const key = argv.key;
 const cert = argv.cert;
@@ -27,7 +28,7 @@ if (argv['log-tag']) {
     });
 }
 
-console.log(`Nimiq NodeJS Client starting (host=${host}, port=${port}, miner=${!!minerOptions}, passive=${!!passive})`);
+console.log(`Nimiq NodeJS Client starting (host=${host}, port=${port}, miner=${!!minerOptions}, statistics=${!!statisticsOptions}, passive=${!!passive})`);
 
 // XXX Configure Core.
 // TODO Create config/options object and pass to Core.get()/init().
@@ -92,21 +93,23 @@ const $ = {};
         Nimiq.Log.i(TAG, `Block mined: ${block.header}`);
     });
 
-    // Output regular statistics
-    const hashrates      = [];
-    const outputInterval = 10; // Seconds
+    if (statisticsOptions) {
+        // Output regular statistics
+        const hashrates      = [];
+        const outputInterval = typeof statisticsOptions === 'number' ? statisticsOptions : 10; // seconds
 
-    $.miner.on('hashrate-changed', async (hashrate) => {
-        hashrates.push(hashrate);
+        $.miner.on('hashrate-changed', async (hashrate) => {
+            hashrates.push(hashrate);
 
-        if(hashrates.length >= outputInterval) {
-            let sum = hashrates.reduce((acc, val) => acc += val);
-            Nimiq.Log.i(TAG, `Hashrate: ${(sum / hashrates.length).toFixed(Math.log10(hashrates.length)).padStart(7)} H/s`
-                        + ` - Balance: ${Nimiq.Policy.satoshisToCoins((await $.accounts.get($.wallet.address)).balance)} NIM`
-                        + ` - Mempool: ${$.mempool.getTransactions().length} tx`);
-            hashrates.length = 0;
-        }
-    });
+            if(hashrates.length >= outputInterval) {
+                let sum = hashrates.reduce((acc, val) => acc += val);
+                Nimiq.Log.i(TAG, `Hashrate: ${(sum / hashrates.length).toFixed(Math.log10(hashrates.length)).padStart(7)} H/s`
+                            + ` - Balance: ${Nimiq.Policy.satoshisToCoins((await $.accounts.get($.wallet.address)).balance)} NIM`
+                            + ` - Mempool: ${$.mempool.getTransactions().length} tx`);
+                hashrates.length = 0;
+            }
+        });
+    }
 })().catch(e => {
     console.error(e);
     process.exit(1);


### PR DESCRIPTION
Output statistics every 10 seconds (currently) in the nodejs miner, to be able to see hashrate, balance and mempool tx, like so:

`[I 22:25:09] Node: Hashrate: 10969.5 H/s - Balance: 4.96298983 NIM - Mempool: 0 tx`

This requires all blockchain-related objects to be availabe in the global scope, thus they are assigned to `$`, just like in the browser.