### PR TITLE
Wallet: allow to create "deep-locked" Wallet

### DIFF
--- a/src/main/generic/utils/buffer/BufferUtils.js
+++ b/src/main/generic/utils/buffer/BufferUtils.js
@@ -191,6 +191,19 @@ class BufferUtils {
         }
         return 0;
     }
+
+    /**
+     * @param {Uint8Array} a
+     * @param {Uint8Array} b
+     * @return {Uint8Array}
+     */
+    static xor(a, b) {
+        const res = new Uint8Array(a.byteLength);
+        for (let i = 0; i < a.byteLength; ++i) {
+            res[i] = a[i] ^ b[i];
+        }
+        return res;
+    }
 }
 BufferUtils.BASE32_ALPHABET = {
     RFC4648:        'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567=',

--- a/src/main/generic/utils/crypto/Crypto.js
+++ b/src/main/generic/utils/crypto/Crypto.js
@@ -304,9 +304,15 @@ class Crypto {
         return worker.computeHardHashBatch(arrarr);
     }
 
-    static async kdf(key, seed) {
+    /**
+     * @param {Uint8Array} key
+     * @param {Uint8Array} salt
+     * @param {number} iterations
+     * @returns {Promise.<Uint8Array>}
+     */
+    static async kdf(key, salt, iterations = 256) {
         const worker = await Crypto._cryptoWorkerAsync();
-        return worker.kdf(key, seed);
+        return worker.kdf(key, salt, iterations);
     }
 
     /**

--- a/src/main/generic/utils/crypto/CryptoWorker.js
+++ b/src/main/generic/utils/crypto/CryptoWorker.js
@@ -34,10 +34,11 @@ class CryptoWorker {
 
     /**
      * @param {Uint8Array} key
-     * @param {Uint8Array} seed
+     * @param {Uint8Array} salt
+     * @param {number} iterations
      * @returns {Promise.<Uint8Array>}
      */
-    async kdf(key, seed) {}
+    async kdf(key, salt, iterations) {}
 
     /**
      * @param privateKey

--- a/src/main/generic/utils/crypto/CryptoWorkerImpl.js
+++ b/src/main/generic/utils/crypto/CryptoWorkerImpl.js
@@ -119,19 +119,20 @@ class CryptoWorkerImpl extends IWorker.Stub(CryptoWorker) {
 
     /**
      * @param {Uint8Array} key
-     * @param {Uint8Array} seed
+     * @param {Uint8Array} salt
+     * @param {number} iterations
      * @returns {Promise.<Uint8Array>}
      */
-    async kdf(key, seed) {
+    async kdf(key, salt, iterations) {
         let stackPtr;
         try {
             stackPtr = Module.stackSave();
             const wasmOut = Module.stackAlloc(CryptoWorker.HASH_SIZE);
             const wasmIn = Module.stackAlloc(key.length);
             new Uint8Array(Module.HEAPU8.buffer, wasmIn, key.length).set(key);
-            const wasmSeed = Module.stackAlloc(seed.length);
-            new Uint8Array(Module.HEAPU8.buffer, wasmSeed, seed.length).set(seed);
-            const res = Module._nimiq_kdf(wasmOut, wasmIn, key.length, wasmSeed, seed.length, 512, 256);
+            const wasmSalt = Module.stackAlloc(salt.length);
+            new Uint8Array(Module.HEAPU8.buffer, wasmSalt, salt.length).set(salt);
+            const res = Module._nimiq_kdf(wasmOut, wasmIn, key.length, wasmSalt, salt.length, 512, iterations);
             if (res !== 0) {
                 throw res;
             }

--- a/src/main/generic/wallet/Wallet.js
+++ b/src/main/generic/wallet/Wallet.js
@@ -1,4 +1,3 @@
-// TODO V2: Store private key encrypted
 class Wallet {
     /**
      * Create a Wallet with persistent storage backend.
@@ -35,6 +34,26 @@ class Wallet {
         }
 
         return new Wallet(KeyPair.fromHex(hexBuf));
+    }
+
+    /**
+     * @param {Uint8Array|string} buf
+     * @param {Uint8Array|string} key
+     * @return {Promise.<Wallet>}
+     */
+    static async loadDeepLocked(buf, key) {
+        if (typeof buf === 'string') buf = BufferUtils.fromHex(buf);
+        if (typeof key === 'string') key = BufferUtils.fromAscii(key);
+        return new Wallet(await KeyPair.deriveDeepLocked(new SerialBuffer(buf), key));
+    }
+
+    /**
+     * @param {Uint8Array|string} key
+     * @return {Promise.<Uint8Array>}
+     */
+    deepLock(key) {
+        if (typeof key === 'string') key = BufferUtils.fromAscii(key);
+        return this._keyPair.deepLock(key);
     }
 
     /**
@@ -94,7 +113,7 @@ class Wallet {
         return this._keyPair;
     }
 
-    /** 
+    /**
      * @returns {string}
      */
     dump() {

--- a/src/test/specs/generic/consensus/base/primitive/KeyPair.spec.js
+++ b/src/test/specs/generic/consensus/base/primitive/KeyPair.spec.js
@@ -16,10 +16,12 @@ describe('KeyPair', () => {
             const key = new Uint8Array([1, 2, 3, 4]);
             const pair1 = await KeyPair.generate();
             const privateKeyBak = PrivateKey.unserialize(pair1.privateKey.serialize());
+
             await pair1.lock(key);
             expect(pair1.isLocked).toBeTruthy();
             const pair2 = KeyPair.unserialize(pair1.serialize());
             expect(pair2.isLocked).toBeTruthy();
+
             await pair2.unlock(key);
             expect(pair2.isLocked).toBeFalsy();
             expect(privateKeyBak).toEqual(pair2.privateKey);
@@ -31,17 +33,24 @@ describe('KeyPair', () => {
             const key = new Uint8Array([1, 2, 3, 4]);
             const pair = await KeyPair.generate();
             const privateKeyBak = PrivateKey.unserialize(pair.privateKey.serialize());
+
             await pair.lock(key);
             expect(pair.isLocked).toBeTruthy();
             expect(() => pair.privateKey).toThrow();
+            expect(pair._unlockedPrivateKey).toBeFalsy();
+            expect(Crypto.keyPairPrivate(pair._obj)).not.toEqual(privateKeyBak);
+
             await pair.unlock(key);
             expect(pair.isLocked).toBeFalsy();
             const privateKeyTmp = pair.privateKey;
             expect(privateKeyTmp).toEqual(privateKeyBak);
+
             pair.relock();
             expect(pair.isLocked).toBeTruthy();
             expect(() => pair.privateKey).toThrow();
+            expect(pair._unlockedPrivateKey).toBeFalsy();
             expect(privateKeyTmp).not.toEqual(privateKeyBak);
+            expect(Crypto.keyPairPrivate(pair._obj)).not.toEqual(privateKeyBak);
         })().then(done, done.fail);
     });
 
@@ -51,12 +60,47 @@ describe('KeyPair', () => {
             const key = new Uint8Array([1, 2, 3, 4]);
             const key2 = new Uint8Array([1, 2, 3, 3]);
             const pair1 = await KeyPair.generate();
+
             await pair1.lock(key);
             await pair1.unlock(key2).catch(catcher.catcher);
             expect(catcher.catcher).toHaveBeenCalled();
             expect(pair1.isLocked).toBeTruthy();
+
             await pair1.unlock(key);
             expect(pair1.isLocked).toBeFalsy();
+        })().then(done, done.fail);
+    });
+
+    it('can lock under different keys', (done) => {
+        (async () => {
+            const key1 = new Uint8Array([1, 2, 3, 4]);
+            const key2 = new Uint8Array([4, 3, 2, 1]);
+
+            const pair = await KeyPair.generate();
+            const privateKeyBak = PrivateKey.unserialize(pair.privateKey.serialize());
+
+            await pair.lock(key1);
+            expect(pair.isLocked).toBeTruthy();
+            expect(() => pair.privateKey).toThrow();
+            expect(pair._unlockedPrivateKey).toBeFalsy();
+            expect(Crypto.keyPairPrivate(pair._obj)).not.toEqual(privateKeyBak);
+
+            await pair.unlock(key1);
+            expect(pair.isLocked).toBeFalsy();
+            let privateKeyTmp = pair.privateKey;
+            expect(privateKeyTmp).toEqual(privateKeyBak);
+
+            await pair.lock(key2);
+            expect(pair.isLocked).toBeTruthy();
+            expect(() => pair.privateKey).toThrow();
+            expect(pair._unlockedPrivateKey).toBeFalsy();
+            expect(privateKeyTmp).not.toEqual(privateKeyBak);
+            expect(Crypto.keyPairPrivate(pair._obj)).not.toEqual(privateKeyBak);
+
+            await pair.unlock(key2);
+            expect(pair.isLocked).toBeFalsy();
+            privateKeyTmp = pair.privateKey;
+            expect(privateKeyTmp).toEqual(privateKeyBak);
         })().then(done, done.fail);
     });
 });


### PR DESCRIPTION
A "deep-locked" wallet is a byte[], consisting of
- The private key, encrypted using the wallet pin and a hard KDF
- The salt used for the KDF
- A 4-byte "checksum" (the first four byte of the hash of the public key)

The public key and address corresponding to a deep-locked wallet are not available while such a wallet is locked. It is thus required to know the wallet pin to import a deep-locked wallet, even if the private key portion is not used.