### PR TITLE
tests: add a test for isPrivateIP with malformed address

### DIFF
--- a/src/test/specs/generic/network/address/NetAddress.spec.js
+++ b/src/test/specs/generic/network/address/NetAddress.spec.js
@@ -174,5 +174,7 @@ describe('NetAddress', () => {
         expect(NetUtils.isPrivateIP('fd00:3456:789a:1::1')).toEqual(true);
         expect(NetUtils.isPrivateIP('fe00:3456:789a:1::1')).toEqual(false);
         expect(NetUtils.isPrivateIP('ff02:3456:789a:1::1')).toEqual(false);
+
+        expect(() => NetUtils.isPrivateIP('not-an-ip')).toThrow("Malformed IP address not-an-ip");
     });
 });


### PR DESCRIPTION
Test that NetUtils.isPrivateIP throws an error when called with a malformed address.

## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts. Confirmation: ¿?

## What's in this pull request?

A test for an uncovered line: https://codecov.io/gh/nimiq-network/core/src/master/src/main/generic/network/NetUtils.js#L44
