### PR TITLE
tests: split the malformed private ip test

### DIFF
--- a/src/test/specs/generic/network/address/NetAddress.spec.js
+++ b/src/test/specs/generic/network/address/NetAddress.spec.js
@@ -174,7 +174,9 @@ describe('NetAddress', () => {
         expect(NetUtils.isPrivateIP('fd00:3456:789a:1::1')).toEqual(true);
         expect(NetUtils.isPrivateIP('fe00:3456:789a:1::1')).toEqual(false);
         expect(NetUtils.isPrivateIP('ff02:3456:789a:1::1')).toEqual(false);
+    });
 
+    it('rejects invalid private IP addresses', () => {
         expect(() => NetUtils.isPrivateIP('not-an-ip')).toThrow('Malformed IP address not-an-ip');
     });
 });


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

## What's in this pull request?

I moved the test for a call to isPrivateIP with a malformed ip to a separate spec, as suggested by @jeffesquivels in https://github.com/nimiq-network/core/pull/303#discussion_r162985422