### PR TITLE
Add tests for WalletStore, fix #322, add equals method to Wallet

### DIFF
--- a/src/main/generic/wallet/Wallet.js
+++ b/src/main/generic/wallet/Wallet.js
@@ -103,6 +103,14 @@ class Wallet {
     }
 
     /**
+     * @param {Wallet} o
+     * @return {boolean}
+     */
+    equals(o) {
+        return o instanceof Wallet && this.keyPair.equals(o.keyPair) && this.address.equals(o.address);
+    }
+
+    /**
      * The address of the Wallet owner.
      * @type {Address}
      */

--- a/src/main/generic/wallet/WalletStore.js
+++ b/src/main/generic/wallet/WalletStore.js
@@ -3,8 +3,8 @@ class WalletStore {
     /**
      * @returns {Promise.<WalletStore>}
      */
-    constructor() {
-        this._jdb = new JDB.JungleDB('wallet', WalletStore.VERSION);
+    constructor(dbName = 'wallet') {
+        this._jdb = new JDB.JungleDB(dbName, WalletStore.VERSION);
         /** @type {ObjectStore} */
         this._walletStore = null;
         /** @type {ObjectStore} */
@@ -102,7 +102,7 @@ class WalletStore {
         // Remove default address as well if they coincide.
         let defaultAddress = await this._walletStore.get('default');
         if (defaultAddress) {
-            defaultAddress = Address.unserialize(defaultAddress);
+            defaultAddress = new Address(defaultAddress);
             if (address.equals(defaultAddress)) {
                 await tx.remove('default');
             }

--- a/src/test/specs/generic/wallet/Wallet.spec.js
+++ b/src/test/specs/generic/wallet/Wallet.spec.js
@@ -4,12 +4,12 @@ describe('Wallet', () => {
     const fee = 888;
     const nonce = 8;
     const deepLockRounds = KeyPair.EXPORT_KDF_ROUNDS;
-    
+
     beforeAll(() => {
         // Temporarily reduce deep lock rounds.
         KeyPair.EXPORT_KDF_ROUNDS = KeyPair.LOCK_KDF_ROUNDS;
     });
-    
+
     afterAll(() => {
         KeyPair.EXPORT_KDF_ROUNDS = deepLockRounds;
     });
@@ -44,8 +44,7 @@ describe('Wallet', () => {
             const wallet = await Wallet.generate();
             const wallet2 = await Wallet.loadPlain(wallet.exportPlain());
 
-            expect(wallet.keyPair.equals(wallet2.keyPair)).toBeTruthy();
-            expect(wallet.address.equals(wallet2.address)).toBeTruthy();
+            expect(wallet.equals(wallet2)).toBeTruthy();
         })().then(done, done.fail);
     });
 

--- a/src/test/specs/generic/wallet/WalletStore.spec.js
+++ b/src/test/specs/generic/wallet/WalletStore.spec.js
@@ -1,0 +1,83 @@
+describe('WalletStore', () => {
+    let walletStore;
+
+    beforeEach((done) => {
+        (async () => {
+            walletStore = await new WalletStore('wallet_test');
+        })().then(done, done.fail);
+    });
+
+    afterEach((done) => {
+        (async () => {
+            await walletStore._jdb.destroy();
+        })().then(done, done.fail);
+    });
+
+    it('can store, retrieve and remove regular wallets', (done) => {
+        (async () => {
+            const wallet1 = await Wallet.generate();
+            const wallet2 = await Wallet.generate();
+
+            expect(await walletStore.list()).toEqual([]);
+
+            await walletStore.put(wallet1);
+            await walletStore.put(wallet2);
+            expect((await walletStore.list()).length).toBe(2);
+
+            readWallet1 = await walletStore.get(wallet1.address);
+            readWallet2 = await walletStore.get(wallet2.address);
+
+            expect(readWallet1.equals(wallet1)).toBeTruthy();
+            expect(readWallet2.equals(wallet2)).toBeTruthy();
+
+            await walletStore.remove(wallet1.address);
+            await walletStore.remove(wallet2.address);
+            expect((await walletStore.list()).length).toBe(0);
+        })().then(done, done.fail);
+    });
+
+    it('can store, retrieve and remove multisig wallets', (done) => {
+        (async () => {
+            const keyPair1 = KeyPair.generate();
+            const keyPair2 = KeyPair.generate();
+
+            const wallet1 = MultiSigWallet.fromPublicKeys(keyPair1, 2, [keyPair1.publicKey, keyPair2.publicKey]);
+            const wallet2 = MultiSigWallet.fromPublicKeys(keyPair2, 2, [keyPair2.publicKey, keyPair1.publicKey]);
+
+            expect(await walletStore.listMultiSig()).toEqual([]);
+
+            await walletStore.putMultiSig(wallet1);
+            await walletStore.putMultiSig(wallet2);
+            expect((await walletStore.listMultiSig()).length).toBe(2);
+
+            readWallet1 = await walletStore.getMultiSig(wallet1.address);
+            readWallet2 = await walletStore.getMultiSig(wallet2.address);
+
+            expect(readWallet1.equals(wallet1)).toBeTruthy();
+            expect(readWallet2.equals(wallet2)).toBeTruthy();
+
+            await walletStore.removeMultiSig(wallet1.address);
+            await walletStore.removeMultiSig(wallet2.address);
+            expect((await walletStore.listMultiSig()).length).toBe(0);
+        })().then(done, done.fail);
+    });
+
+    it('can store, retrieve and remove a default wallet', (done) => {
+        (async () => {
+            const wallet1 = await Wallet.generate();
+
+            expect(await walletStore.list()).toEqual([]);
+
+            await walletStore.put(wallet1);
+            expect((await walletStore.list()).length).toBe(1);
+
+            await walletStore.setDefault(wallet1.address);
+            expect(await walletStore.hasDefault()).toBeTruthy();
+            expect((await walletStore.getDefault()).equals(wallet1)).toBeTruthy();
+
+            await walletStore.remove(wallet1.address);
+            expect((await walletStore.list()).length).toBe(0);
+            expect(await walletStore.hasDefault()).toBeFalsy();
+        })().then(done, done.fail);
+    });
+});


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

#### This fixes issue #322.

## What's in this pull request?

- Tests for `WalletStore`
- Fix for #322 
- New `equals()` method for `Wallet`
