### PR TITLE
fix BufferUtils.fromHex in JsonRpcServer.sendRawTransaction

### DIFF
--- a/clients/nodejs/JsonRpcServer.js
+++ b/clients/nodejs/JsonRpcServer.js
@@ -35,7 +35,7 @@ class JsonRpcServer {
 
         // Transactions
         this._methods.set('sendRawTransaction', async (txhex) => {
-            const tx = Nimiq.Transaction.unserialize(BufferUtils.fromHex(txhex));
+            const tx = Nimiq.Transaction.unserialize(Nimiq.BufferUtils.fromHex(txhex));
             const ret = await mempool.pushTransaction(tx);
             if (ret < 0) {
                 const e = new Error(`Transaction not accepted: ${ret}`);


### PR DESCRIPTION
The JSON-RPC call `sendRawTransaction` in the nodejs client fails, because `BufferUtils` is undefined. The correct name is `Nimiq.BufferUtils`. This commit fixed that.