### PR TITLE
Remove refactoring-induced test duplication

### DIFF
--- a/src/test/specs/generic/consensus/Genesis.spec.js
+++ b/src/test/specs/generic/consensus/Genesis.spec.js
@@ -3,6 +3,12 @@ describe('Genesis', () => {
         Crypto.prepareSyncCryptoWorker().then(done, done.fail);
     });
 
+    it('light Block is valid (testing)', (done) => {
+        (async () => {
+            expect(await Block.GENESIS.toLight().verify(new Time())).toBeTruthy();
+        })().then(done, done.fail);
+    });
+
     it('Block is valid (testing)', (done) => {
         (async () => {
             time = new Time();

--- a/src/test/specs/generic/consensus/base/block/Block.spec.js
+++ b/src/test/specs/generic/consensus/base/block/Block.spec.js
@@ -93,32 +93,4 @@ describe('Block', () => {
         expect(block3.isFull()).toBeTruthy();
         expect(block3.equals(Block.GENESIS)).toBeTruthy();
     });
-
-    it('light GENESIS is valid (testing)', (done) => {
-        (async () => {
-            expect(await Block.GENESIS.toLight().verify(new Time())).toBeTruthy();
-        })().then(done, done.fail);
-    });
-
-    it('GENESIS is valid (testing)', (done) => {
-        (async () => {
-            time = new Time();
-            expect(await Block.GENESIS.verify(time)).toBeTruthy();
-        })().then(done, done.fail);
-    });
-
-    it('GENESIS.HASH matches GENESIS.hash() (testing)', () => {
-        expect(Block.GENESIS.HASH.equals(Block.GENESIS.hash())).toBeTruthy();
-    });
-
-    it('GENESIS is valid (real)', (done) => {
-        (async () => {
-            time = new Time();
-            expect(await Block.OLD_GENESIS.verify(time)).toBeTruthy();
-        })().then(done, done.fail);
-    });
-
-    it('GENESIS.HASH matches GENESIS.hash() (real)', () => {
-        expect(Block.OLD_GENESIS.HASH.equals(Block.OLD_GENESIS.hash())).toBeTruthy();
-    });
 });


### PR DESCRIPTION
8d31e90 added a test 'light GENESIS is valid (testing)' to Block.spec.js, but 8e82e31 moved the other Genesis tests into Genesis.spec.js. After refactoring, 8d31e90 adds them back.