### PR TITLE
Add 'transaction-requested' event to NanoMempool

### DIFF
--- a/src/main/generic/consensus/BaseConsensusAgent.js
+++ b/src/main/generic/consensus/BaseConsensusAgent.js
@@ -748,6 +748,7 @@ class BaseConsensusAgent extends Observable {
                     if (tx) {
                         // We have found a requested transaction, send it back to the sender.
                         this._peer.channel.tx(tx);
+                        this.fire('transaction-relayed', tx);
                     } else {
                         // Requested transaction is unknown.
                         unknownObjects.push(vector);

--- a/src/main/generic/consensus/nano/NanoConsensus.js
+++ b/src/main/generic/consensus/nano/NanoConsensus.js
@@ -43,7 +43,7 @@ class NanoConsensus extends BaseConsensus {
         const agent = super._onPeerJoined(peer);
 
         // Forward sync events.
-        this.bubble(agent, 'sync-chain-proof', 'verify-chain-proof');
+        this.bubble(agent, 'sync-chain-proof', 'verify-chain-proof', 'transaction-relayed');
 
         return agent;
     }

--- a/src/main/generic/consensus/nano/NanoConsensus.js
+++ b/src/main/generic/consensus/nano/NanoConsensus.js
@@ -122,7 +122,7 @@ class NanoConsensus extends BaseConsensus {
         }
 
         // Store transaction in mempool.
-        if (!(await this._mempool.pushTransaction(transaction))) {
+        if (!(await this._mempool.pushTransaction(transaction, true))) {
             throw new Error('Failed to relay transaction - mempool rejected transaction');
         }
 

--- a/src/main/generic/consensus/nano/NanoConsensus.js
+++ b/src/main/generic/consensus/nano/NanoConsensus.js
@@ -122,7 +122,7 @@ class NanoConsensus extends BaseConsensus {
         }
 
         // Store transaction in mempool.
-        if (!(await this._mempool.pushTransaction(transaction, true))) {
+        if (!(await this._mempool.pushTransaction(transaction))) {
             throw new Error('Failed to relay transaction - mempool rejected transaction');
         }
 

--- a/src/main/generic/consensus/nano/NanoMempool.js
+++ b/src/main/generic/consensus/nano/NanoMempool.js
@@ -56,7 +56,11 @@ class NanoMempool extends Observable {
      * @returns {Transaction}
      */
     getTransaction(hash) {
-        return this._transactionsByHash.get(hash);
+        const transaction = this._transactionsByHash.get(hash);
+        if (transaction) {
+            this.fire('transaction-requested', transaction);
+        }
+        return transaction;
     }
 
     /**

--- a/src/main/generic/consensus/nano/NanoMempool.js
+++ b/src/main/generic/consensus/nano/NanoMempool.js
@@ -90,6 +90,23 @@ class NanoMempool extends Observable {
     }
 
     /**
+     * @param {Transaction} transaction
+     */
+    removeTransaction(transaction) {
+        this._transactionsByHash.remove(transaction.hash());
+
+        /** @type {MempoolTransactionSet} */
+        const set = this._transactionSetByAddress.get(transaction.sender);
+        set.remove(transaction);
+
+        if (set.length === 0) {
+            this._transactionSetByAddress.remove(transaction.sender);
+        }
+
+        this.fire('transaction-removed', tx);
+    }
+
+    /**
      * @param {Array.<Address>} addresses
      */
     evictExceptAddresses(addresses) {
@@ -97,15 +114,7 @@ class NanoMempool extends Observable {
         addressSet.addAll(addresses);
         for (const /** @type {Transaction} */ tx of this._transactionsByHash.values()) {
             if (!addressSet.contains(tx.sender) && !addressSet.contains(tx.recipient)) {
-                this._transactionsByHash.remove(tx.hash());
-
-                /** @type {MempoolTransactionSet} */
-                const set = this._transactionSetByAddress.get(tx.sender);
-                set.remove(tx);
-
-                if (set.length === 0) {
-                    this._transactionSetByAddress.remove(tx.sender);
-                }
+                this.removeTransaction(tx);
             }
         }
     }
@@ -120,18 +129,9 @@ class NanoMempool extends Observable {
         for (const /** @type {Transaction} */ tx of this._transactionsByHash.values()) {
             const txHash = tx.hash();
             if (blockHeader.height >= tx.validityStartHeight + Policy.TRANSACTION_VALIDITY_WINDOW) {
-                this._transactionsByHash.remove(txHash);
-
-                /** @type {MempoolTransactionSet} */
-                const set = this._transactionSetByAddress.get(tx.sender);
-                set.remove(tx);
-
-                if (set.length === 0) {
-                    this._transactionSetByAddress.remove(tx.sender);
-                }
+                this.removeTransaction(tx);
 
                 this.fire('transaction-expired', tx);
-                this.fire('transaction-removed', tx);
             }
         }
 
@@ -139,18 +139,9 @@ class NanoMempool extends Observable {
         for (const /** @type {Transaction} */ tx of transactions) {
             const txHash = tx.hash();
             if (this._transactionsByHash.contains(txHash)) {
-                this._transactionsByHash.remove(txHash);
-
-                /** @type {MempoolTransactionSet} */
-                const set = this._transactionSetByAddress.get(tx.sender);
-                set.remove(tx);
-
-                if (set.length === 0) {
-                    this._transactionSetByAddress.remove(tx.sender);
-                }
+                this.removeTransaction(tx);
 
                 this.fire('transaction-mined', tx, blockHeader);
-                this.fire('transaction-removed', tx);
             }
         }
     }

--- a/src/main/generic/consensus/nano/NanoMempool.js
+++ b/src/main/generic/consensus/nano/NanoMempool.js
@@ -17,10 +17,11 @@ class NanoMempool extends Observable {
 
     /**
      * @param {Transaction} transaction
+     * @param {boolean} [isSelfRelayed]
      * @fires Mempool#transaction-added
      * @returns {Promise.<boolean>}
      */
-    async pushTransaction(transaction) {
+    async pushTransaction(transaction, isSelfRelayed = false) {
         // Check if we already know this transaction.
         const hash = transaction.hash();
         if (this._transactionsByHash.contains(hash)) {
@@ -46,7 +47,7 @@ class NanoMempool extends Observable {
         this._transactionSetByAddress.put(transaction.sender, set);
 
         // Tell listeners about the new transaction we received.
-        this.fire('transaction-added', transaction);
+        this.fire('transaction-added', transaction, isSelfRelayed);
 
         return true;
     }

--- a/src/main/generic/consensus/nano/NanoMempool.js
+++ b/src/main/generic/consensus/nano/NanoMempool.js
@@ -98,7 +98,7 @@ class NanoMempool extends Observable {
             this._transactionSetByAddress.remove(transaction.sender);
         }
 
-        this.fire('transaction-removed', tx);
+        this.fire('transaction-removed', transaction);
     }
 
     /**

--- a/src/main/generic/consensus/nano/NanoMempool.js
+++ b/src/main/generic/consensus/nano/NanoMempool.js
@@ -56,11 +56,7 @@ class NanoMempool extends Observable {
      * @returns {Transaction}
      */
     getTransaction(hash) {
-        const transaction = this._transactionsByHash.get(hash);
-        if (transaction) {
-            this.fire('transaction-requested', transaction);
-        }
-        return transaction;
+        return this._transactionsByHash.get(hash);
     }
 
     /**

--- a/src/main/generic/consensus/nano/NanoMempool.js
+++ b/src/main/generic/consensus/nano/NanoMempool.js
@@ -17,11 +17,10 @@ class NanoMempool extends Observable {
 
     /**
      * @param {Transaction} transaction
-     * @param {boolean} [isSelfRelayed]
      * @fires Mempool#transaction-added
      * @returns {Promise.<boolean>}
      */
-    async pushTransaction(transaction, isSelfRelayed = false) {
+    async pushTransaction(transaction) {
         // Check if we already know this transaction.
         const hash = transaction.hash();
         if (this._transactionsByHash.contains(hash)) {
@@ -47,7 +46,7 @@ class NanoMempool extends Observable {
         this._transactionSetByAddress.put(transaction.sender, set);
 
         // Tell listeners about the new transaction we received.
-        this.fire('transaction-added', transaction, isSelfRelayed);
+        this.fire('transaction-added', transaction);
 
         return true;
     }


### PR DESCRIPTION
This event is required for the NanoMempool to have assurance that its relayed transaction really arrived in the peers' mempool.

It is used to only show the transaction as pending in the UI when this event is fired for the transaction.