### PR TITLE
Make packaging compatible with latest core changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ settings.json
 packaging/BUILD/VERSION
 packaging/BUILD/fakeroot/
 packaging/BUILD/index.js
+packaging/BUILD/build/
 packaging/BUILD/lib/
 packaging/BUILD/modules/
 packaging/BUILD/nimiq

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -538,7 +538,6 @@ const RELEASE_SOURCES = [
 const RELEASE_LIB = [
     'dist/node.*',
     'dist/worker-*',
-    'build/Release/nimiq_node_generic.node'
 ];
 
 gulp.task('prepare-packages', ['build-node'], function () {
@@ -550,6 +549,7 @@ gulp.task('prepare-packages', ['build-node'], function () {
     gulp.src(['clients/nodejs/modules/*.js']).pipe(replace('../../../dist/node.js', '../lib/node.js')).pipe(gulp.dest('packaging/BUILD/modules'));
     gulp.src(['node_modules/**/*'], {base: '.', dot: true }).pipe(gulp.dest('packaging/BUILD'));
     gulp.src(RELEASE_LIB).pipe(gulp.dest('packaging/BUILD/lib'));
+    gulp.src('build/Release/nimiq_node_generic.node').pipe(gulp.dest('packaging/BUILD/build'));
 });
 
 gulp.task('test', ['watch'], function () {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "prepare": "gulp build-node",
     "build": "gulp build",
-    "build-deb": "gulp --architecture=`dpkg --print-architecture` prepare-packages && cd packaging/BUILD && mv lib/nimiq_node_generic.node lib/nimiq_node.node && mv fakeroot/etc/nimiq/sample.conf fakeroot/etc/nimiq/nimiq.conf && node-deb --no-default-package-dependencies x -- node *.js cron-deb.sh VERSION lib/ modules/ && mv *.deb ../../dist/",
-    "build-rpm": "gulp --architecture=`arch` prepare-packages && cd packaging && mv BUILD/lib/nimiq_node_generic.node BUILD/lib/nimiq_node.node && mv BUILD/fakeroot/etc/nimiq/sample.conf BUILD/fakeroot/etc/nimiq/nimiq.conf && rpmbuild -bb SPECS/nimiq.spec && mv RPMS/x86_64/*.rpm ../dist",
+    "build-deb": "gulp --architecture=`dpkg --print-architecture` prepare-packages && cd packaging/BUILD && mv build/nimiq_node_generic.node build/nimiq_node.node && mv fakeroot/etc/nimiq/sample.conf fakeroot/etc/nimiq/nimiq.conf && node-deb --no-default-package-dependencies x -- node *.js cron-deb.sh VERSION build/ lib/ modules/ && mv *.deb ../../dist/",
+    "build-rpm": "gulp --architecture=`arch` prepare-packages && cd packaging && mv BUILD/build/nimiq_node_generic.node BUILD/build/nimiq_node.node && mv BUILD/fakeroot/etc/nimiq/sample.conf BUILD/fakeroot/etc/nimiq/nimiq.conf && rpmbuild -bb SPECS/nimiq.spec && mv RPMS/x86_64/*.rpm ../dist",
     "esdoc": "esdoc",
     "test": "jasmine && gulp test",
     "test-node": "jasmine",

--- a/packaging/SPECS/nimiq.spec
+++ b/packaging/SPECS/nimiq.spec
@@ -4,7 +4,7 @@
 %define _topdir %(echo $PWD)/
 
 Name:           nimiq
-Version:        1.0.0
+Version:        1.1.0
 Release:        1
 Summary:        Nimiq node.js client
 
@@ -46,7 +46,7 @@ install -m 0666 nimiq.repo %{buildroot}%{_sysconfdir}/yum.repos.d/
 install -m 0666 RPM-GPG-KEY-nimiq %{buildroot}%{_sysconfdir}/pki/rpm-gpg/
 install -m 0755 node %{buildroot}%{_datarootdir}/%{name}/
 install -m 0644 index.js package.json VERSION %{buildroot}%{_datarootdir}/%{name}/
-cp -r lib/ modules/ node_modules/ %{buildroot}%{_datarootdir}/%{name}/
+cp -r build/ lib/ modules/ node_modules/ %{buildroot}%{_datarootdir}/%{name}/
 install -m 0644 systemd.service %{buildroot}%{_unitdir}/%{name}.service
 
 
@@ -59,6 +59,7 @@ install -m 0644 systemd.service %{buildroot}%{_unitdir}/%{name}.service
 %{_datarootdir}/%{name}/package.json
 %{_datarootdir}/%{name}/VERSION
 %{_datarootdir}/%{name}/lib
+%{_datarootdir}/%{name}/build
 %{_datarootdir}/%{name}/modules
 %{_datarootdir}/%{name}/node_modules
 %{_unitdir}/%{name}.service


### PR DESCRIPTION
This PR includes changes to the packaging system to make it compatible with the new way to load node addons (i.e. via the `bindings` module).

There is also one other change needed to be able to successfully build deb packages (rpm packages build correctly with just this PR), but it is incompatible with building nimiq's npm package, so I'm keeping it on a separated branch ([package_building_extra](https://github.com/nimiq-network/core/tree/package_building_extra)) while the packaging support is refactored to support this and other optimizations.