### PR TITLE
Fix deb package building

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "src/native"
   ],
   "node_deb": {
+    "package_name": "nimiq",
+    "version": "1.1.1-1",
     "init": "systemd",
     "architecture": "none",
     "install_strategy": "copy",


### PR DESCRIPTION
This commit moves the `package-name` and `version` arguments for `node-deb` into better scoped fields so that it doesn't tries to get them from the general `name` and `version` fields (which prevents conflicts), thus re-enabling `deb` package building directly from the core repo without any extra modification.