### PR TITLE
Enable offset parameter in GetTransactionReceiptsMessage

### DIFF
--- a/src/main/generic/consensus/BaseConsensus.js
+++ b/src/main/generic/consensus/BaseConsensus.js
@@ -306,10 +306,11 @@ class BaseConsensus extends Observable {
 
     /**
      * @param {Address} address
+     * @param {number} [offset]
      * @returns {Promise.<Array.<TransactionReceipt>>}
      * @protected
      */
-    async _requestTransactionReceipts(address) {
+    async _requestTransactionReceipts(address, offset) {
         const agents = [];
         for (const agent of this._agents.valueIterator()) {
             if (agent.synced
@@ -321,7 +322,7 @@ class BaseConsensus extends Observable {
 
         for (const /** @type {BaseConsensusAgent} */ agent of agents) {
             try {
-                return await agent.getTransactionReceipts(address); // eslint-disable-line no-await-in-loop
+                return await agent.getTransactionReceipts(address, offset); // eslint-disable-line no-await-in-loop
             } catch (e) {
                 Log.w(BaseConsensus, `Failed to retrieve transaction receipts for ${address} from ${agent.peer.peerAddress}: ${e.message || e}`);
                 // Try the next peer.

--- a/src/main/generic/consensus/BaseConsensusAgent.js
+++ b/src/main/generic/consensus/BaseConsensusAgent.js
@@ -1002,10 +1002,11 @@ class BaseConsensusAgent extends Observable {
 
     /**
      * @param {Address} address
+     * @param {number} [offset]
      * @returns {Promise.<Array.<TransactionReceipt>>}
      * @private
      */
-    _getTransactionReceipts(address) {
+    _getTransactionReceipts(address, offset) {
         Assert.that(this._transactionReceiptsRequest === null);
 
         return new Promise((resolve, reject) => {
@@ -1015,7 +1016,7 @@ class BaseConsensusAgent extends Observable {
                 reject
             };
 
-            this._peer.channel.getTransactionReceipts(address);
+            this._peer.channel.getTransactionReceipts(address, offset);
 
             this._peer.channel.expectMessage(Message.Type.TRANSACTION_RECEIPTS, () => {
                 this._peer.channel.close(CloseType.GET_TRANSACTION_RECEIPTS_TIMEOUT, 'getTransactionReceipts timeout');

--- a/src/main/generic/consensus/base/transaction/index/TransactionStore.js
+++ b/src/main/generic/consensus/base/transaction/index/TransactionStore.js
@@ -89,33 +89,41 @@ class TransactionStore {
     /**
      * @param {Address} sender
      * @param {number} [limit]
-     * @returns {Promise.<Array.<TransactionStoreEntry>>}
+     * @param {number} [offset]
+     * @returns {Promise.<Object.<entries: Array.<TransactionStoreEntry, counter: number>>}
      */
-    async getBySender(sender, limit = null) {
+    async getBySender(sender, limit = null, offset = null) {
         const index = this._store.index('sender');
         const entries = [];
+        let counter = 0;
         await index.valueStream((value, key) => {
+            counter++;
+            if (offset !== null && counter <= offset) return true;
             if (limit !== null && entries.length >= limit) return false;
             entries.push(value);
             return true;
         }, /*ascending*/ false, JDB.KeyRange.only(sender.serialize()));
-        return entries;
+        return { entries, counter };
     }
 
     /**
      * @param {Address} recipient
      * @param {?number} [limit]
-     * @returns {Promise.<Array.<TransactionStoreEntry>>}
+     * @param {number} [offset]
+     * @returns {Promise.<Object.<entries: Array.<TransactionStoreEntry, counter: number>>}
      */
-    async getByRecipient(recipient, limit = null) {
+    async getByRecipient(recipient, limit = null, offset = null) {
         const index = this._store.index('recipient');
         const entries = [];
+        let counter = 0;
         await index.valueStream((value, key) => {
+            counter++;
+            if (offset !== null && counter <= offset) return true;
             if (limit !== null && entries.length >= limit) return false;
             entries.push(value);
             return true;
         }, /*ascending*/ false, JDB.KeyRange.only(recipient.serialize()));
-        return entries;
+        return { entries, counter };
     }
 
     /**

--- a/src/main/generic/consensus/full/FullChain.js
+++ b/src/main/generic/consensus/full/FullChain.js
@@ -539,22 +539,27 @@ class FullChain extends BaseChain {
     /**
      * @param {Address} address
      * @param {?number} [limit]
+     * @param {?number} [offset]
      * @returns {Promise.<Array.<TransactionReceipt>>}
      */
-    async getTransactionReceiptsByAddress(address, limit = null) {
+    async getTransactionReceiptsByAddress(address, limit = null, offset = null) {
         if (!this._transactionStore) {
             return null;
         }
 
         const transactionReceipts = [];
-        const entriesBySender = await this._transactionStore.getBySender(address, limit);
-        const entriesByRecipient = await this._transactionStore.getByRecipient(address, limit === null ? null : Math.max(0, limit - entriesBySender.length));
+        const entriesBySender = await this._transactionStore.getBySender(address, limit, offset);
+        const entriesByRecipient = await this._transactionStore.getByRecipient(
+            address,
+            limit === null ? null : Math.max(0, limit - entriesBySender.entries.length),
+            offset === null || entriesBySender.entries.length > 0 ? null : Math.max(0, offset - entriesBySender.counter)
+        );
 
-        entriesBySender.forEach(entry => {
+        entriesBySender.entries.forEach(entry => {
             transactionReceipts.push(new TransactionReceipt(entry.transactionHash, entry.blockHash, entry.blockHeight));
         });
 
-        entriesByRecipient.forEach(entry => {
+        entriesByRecipient.entries.forEach(entry => {
             transactionReceipts.push(new TransactionReceipt(entry.transactionHash, entry.blockHash, entry.blockHeight));
         });
 

--- a/src/main/generic/consensus/full/FullConsensusAgent.js
+++ b/src/main/generic/consensus/full/FullConsensusAgent.js
@@ -504,7 +504,7 @@ class FullConsensusAgent extends BaseConsensusAgent {
             return;
         }
 
-        const receipts = await this._blockchain.getTransactionReceiptsByAddress(msg.address, TransactionReceiptsMessage.RECEIPTS_MAX_COUNT);
+        const receipts = await this._blockchain.getTransactionReceiptsByAddress(msg.address, TransactionReceiptsMessage.RECEIPTS_MAX_COUNT, msg.offset);
         this._peer.channel.transactionReceipts(receipts);
     }
 

--- a/src/main/generic/network/connection/PeerChannel.js
+++ b/src/main/generic/network/connection/PeerChannel.js
@@ -335,10 +335,11 @@ class PeerChannel extends Observable {
 
     /**
      * @param {Address} address
+     * @param {number} [offset]
      * @returns {boolean}
      */
-    getTransactionReceipts(address) {
-        return this._send(new GetTransactionReceiptsMessage(address));
+    getTransactionReceipts(address, offset) {
+        return this._send(new GetTransactionReceiptsMessage(address, offset));
     }
 
     /**

--- a/src/test/specs/generic/consensus/base/transaction/index/TransactionStore.spec.js
+++ b/src/test/specs/generic/consensus/base/transaction/index/TransactionStore.spec.js
@@ -32,16 +32,16 @@ describe('TransactionStore', () => {
     it('can store and remove transactions', (done) => {
         (async () => {
             await transactionStore.put(block);
-            expect((await transactionStore.getBySender(senderAddress)).length).toBe(3);
+            expect((await transactionStore.getBySender(senderAddress)).entries.length).toBe(3);
             await transactionStore.remove(block);
-            expect((await transactionStore.getBySender(senderAddress)).length).toBe(0);
+            expect((await transactionStore.getBySender(senderAddress)).entries.length).toBe(0);
         })().then(done, done.fail);
     });
 
     it('can retrieve transactions by senderAddress', (done) => {
         (async () => {
             await transactionStore.put(block);
-            const results = await transactionStore.getBySender(senderAddress);
+            const results = (await transactionStore.getBySender(senderAddress)).entries;
             expect(results.length).toBe(3);
 
             for (const entry of results) {
@@ -55,14 +55,14 @@ describe('TransactionStore', () => {
     it('can retrieve transactions by recipientAddress', (done) => {
         (async () => {
             await transactionStore.put(block);
-            let results = await transactionStore.getByRecipient(recipientAddress1);
+            let results = (await transactionStore.getByRecipient(recipientAddress1)).entries;
             expect(results.length).toBe(2);
 
             for (const entry of results) {
                 expect(entry.recipient.equals(recipientAddress1)).toBeTruthy();
             }
 
-            results = await transactionStore.getByRecipient(recipientAddress2);
+            results = (await transactionStore.getByRecipient(recipientAddress2)).entries;
             expect(results.length).toBe(1);
 
             for (const entry of results) {


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

#### This fixes issue #398.

## What's in this pull request?
This pull request enables the use of the optional `offset` parameter of the `GetTransactionReceiptsMessage`.
