### PR TITLE
Support for different websocket engines

### DIFF
--- a/clients/nodejs/nimiq
+++ b/clients/nodejs/nimiq
@@ -12,5 +12,5 @@ else
     exit
 fi
 
-UV_THREADPOOL_SIZE=$NUM_CORES NODE_OPTIONS="--max_old_space_size=$MB_MEMORY" exec node "$SCRIPT_PATH/index.js" "$@"
+NIMIQ_WS_ENGINE="uws" UV_THREADPOOL_SIZE=$NUM_CORES NODE_OPTIONS="--max_old_space_size=$MB_MEMORY" exec node "$SCRIPT_PATH/index.js" "$@"
 

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "lodash.merge": "^4.6.1",
     "minimist": "^1.2.0",
     "nan": "^2.10.0",
-    "uws": "^10.148.0"
+    "uws": "^10.148.0",
+    "ws": "^5.2.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/main/platform/nodejs/index.prefix.js
+++ b/src/main/platform/nodejs/index.prefix.js
@@ -5,9 +5,11 @@ const JDB = require('@nimiq/jungle-db');
 const fs = require('fs');
 const dns = require('dns');
 const https = require('https');
-const WebSocket = require('uws');
 const NodeNative = require('bindings')('nimiq_node.node');
 const chalk = require('chalk');
+
+// Allow the user to specify the WebSocket engine through an environment variable. Default to ws
+const WebSocket = require(process.env.NIMIQ_WS_ENGINE || 'ws');
 
 global.Class = {
     scope: module.exports,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7944,6 +7944,12 @@ write@^0.2.1:
   dependencies:
     mkdirp "^0.5.1"
 
+ws@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.0.tgz#9fd95e3ac7c76f6ae8bcc868a0e3f11f1290c33e"
+  dependencies:
+    async-limiter "~1.0.0"
+
 ws@~3.3.1:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/ws/-/ws-3.3.3.tgz#f1cf84fe2d5e901ebce94efaece785f187a228f2"


### PR DESCRIPTION
This PR introduces support for different websocket engines, the user can choose which to use by setting an environment variable, the code defaults to `ws`, but if the user uses the `nimiq` script to start nimiq (i.e. they're using Linux or Mac) the script will set `uws` for them (since it has higher performance and it seems to work fine on those OSes).