### PR TITLE
use exec in nimiq nodejs wrapper script

### DIFF
--- a/clients/nodejs/nimiq
+++ b/clients/nodejs/nimiq
@@ -8,9 +8,9 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     MB_MEMORY=$(sysctl hw.memsize | awk '{mb =int($2/1024/1024); print mb}')
 else
-    node "$SCRIPT_PATH/index.js" "$@"
+    exec node "$SCRIPT_PATH/index.js" "$@"
     exit
 fi
 
-UV_THREADPOOL_SIZE=$NUM_CORES NODE_OPTIONS="--max_old_space_size=$MB_MEMORY" node "$SCRIPT_PATH/index.js" "$@"
+UV_THREADPOOL_SIZE=$NUM_CORES NODE_OPTIONS="--max_old_space_size=$MB_MEMORY" exec node "$SCRIPT_PATH/index.js" "$@"
 


### PR DESCRIPTION
## Pull request checklist

- [ ] All tests pass. Demo project builds and runs.
- [ ] I have resolved any merge conflicts.

#### This fixes issue #___.

## What's in this pull request?

Use exec in the nimiq nodejs wrapper script to replace the shell by the node process in order to facilitate proper UNIX signal forwarding, e.g. for correctly delivering a SIGTERM signal to a docker container.