### PR TITLE
Handle empty remoteAddress

### DIFF
--- a/src/main/generic/network/websocket/WebSocketConnector.js
+++ b/src/main/generic/network/websocket/WebSocketConnector.js
@@ -146,7 +146,7 @@ class WebSocketConnector extends Observable {
             }
         }
 
-        const netAddress = NetAddress.fromIP(remoteAddress, true);
+        const netAddress = remoteAddress ? NetAddress.fromIP(remoteAddress, true) : null;
         const conn = new NetworkConnection(new WebSocketDataChannel(ws), Protocol.WS, netAddress, /*peerAddress*/ null);
 
         /**

--- a/src/main/generic/network/websocket/WebSocketConnector.js
+++ b/src/main/generic/network/websocket/WebSocketConnector.js
@@ -126,7 +126,7 @@ class WebSocketConnector extends Observable {
      * @returns {void}
      */
     _onConnection(ws, req) {
-        let remoteAddress = ws._socket.remoteAddress;
+        let remoteAddress = req.connection.remoteAddress;
 
         Log.v(WebSocketConnector, () => `These are all the headers I see: ${JSON.stringify(req.headers)}`);
 
@@ -146,7 +146,7 @@ class WebSocketConnector extends Observable {
             }
         }
 
-        const netAddress = remoteAddress ? NetAddress.fromIP(remoteAddress, true) : null;
+        const netAddress = remoteAddress ? NetAddress.fromIP(remoteAddress, true) : NetAddress.UNKNOWN;
         const conn = new NetworkConnection(new WebSocketDataChannel(ws), Protocol.WS, netAddress, /*peerAddress*/ null);
 
         /**

--- a/src/main/platform/nodejs/network/websocket/WebSocketFactory.js
+++ b/src/main/platform/nodejs/network/websocket/WebSocketFactory.js
@@ -18,6 +18,9 @@ class WebSocketFactory {
             res.end('Nimiq NodeJS Client\n');
         }).listen(port);
 
+        // We have to access socket.remoteAddress here because otherwise req.connection.remoteAddress won't be set in the WebSocket's 'connection' event (yay)
+        httpsServer.on('secureConnection', socket => socket.remoteAddress);
+
         return new WebSocket.Server({ server: httpsServer });
     }
 

--- a/src/test/specs/generic/network/MockNetwork.spec.js
+++ b/src/test/specs/generic/network/MockNetwork.spec.js
@@ -344,7 +344,12 @@ class MockNetwork {
 
             setTimeout(() => {
                 if (serverMockWebSocket.closed || client.closed) return;
-                server.fire('connection', serverMockWebSocket);
+                const request = {
+                    connection: {
+                        remoteAddress: client.localAddress
+                    }
+                };
+                server.fire('connection', serverMockWebSocket, request);
                 client.onopen();
             }, 0);
         } else {


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

## What's in this pull request?
This PR adds a short conditional that handles potentially empty websocket `remoteAddresses`. It uses the same logic as in [L52](https://github.com/nimiq-network/core/pull/412/files#diff-f2613a48405e3b1fd5815e76b1496c65L52).
