### PR TITLE
Fixed typo from lt(1) to lte(1)

### DIFF
--- a/src/main/generic/consensus/base/blockchain/BaseChain.js
+++ b/src/main/generic/consensus/base/blockchain/BaseChain.js
@@ -143,7 +143,7 @@ class BaseChain extends IBlockchain {
             }
         }
 
-        if (!tailData || tailData.totalDifficulty.lt(1)) {
+        if (!tailData || tailData.totalDifficulty.lte(1)) {
             // Not enough blocks are available to compute the next target, fail.
             return null;
         }


### PR DESCRIPTION
Typo causes "PeerChannel: Error while processing 'block' message. TypeError: tailData.totalDifficulty.lt is not a function" when trying to reach consensus in light mode starting with block height = 1


