### PR TITLE
Update split eols to keep compatibility across platforms

### DIFF
--- a/src/main/generic/network/address/SeedList.js
+++ b/src/main/generic/network/address/SeedList.js
@@ -19,7 +19,7 @@ class SeedList {
 
         // Filter empty and comment lines.
         const lines = listStr
-            .split('\n')
+            .split(/\r\n|\n|\r/)
             .filter(line => line.length > 0 && !line.startsWith('#'));
 
         // Read seed addresses. Ignore the last line here.


### PR DESCRIPTION
seed.txt created or edited in Windows will trigger 'Ignoring malformed seed address' errors on empty lines. Updated to check for all combinations between Windows, Mac and Linux.