### PR TITLE
Show an error message if the local time is wrong

### DIFF
--- a/clients/nodejs/index.js
+++ b/clients/nodejs/index.js
@@ -266,10 +266,10 @@ const $ = {};
         Nimiq.Log.i(TAG, `Disconnected from ${peer.peerAddress.toString()}`);
     });
 
+    const isSeed = (peerAddress) => Nimiq.GenesisConfig.SEED_PEERS.some(seed => seed.equals(peerAddress));
     $.network.on('peer-joined', (peer) => {
-        const isSeed = Nimiq.GenesisConfig.SEED_PEERS.some((seed) => seed.toString() === peer.peerAddress.toString());
-        if(isSeed && peer.timeOffset > Nimiq.Network.TIME_OFFSET_MAX) {
-            Nimiq.Log.e(TAG, 'Your local system time seems to be wrong');
+        if (Math.abs(peer.timeOffset) > Nimiq.Network.TIME_OFFSET_MAX && isSeed(peer.peerAddress)) {
+            Nimiq.Log.e(TAG, 'Your local system time seems to be wrong! You might not be able to synchronize with the network.');
         }
     });
 

--- a/clients/nodejs/index.js
+++ b/clients/nodejs/index.js
@@ -266,6 +266,13 @@ const $ = {};
         Nimiq.Log.i(TAG, `Disconnected from ${peer.peerAddress.toString()}`);
     });
 
+    $.network.on('peer-joined', (peer) => {
+        const isSeed = Nimiq.GenesisConfig.SEED_PEERS.some((seed) => seed.toString() === peer.peerAddress.toString());
+        if(isSeed && peer.timeOffset > Nimiq.Network.TIME_OFFSET_MAX) {
+            Nimiq.Log.e(TAG, 'Your local system time seems to be wrong');
+        }
+    });
+
     if (!config.passive) {
         $.network.connect();
     }


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

## What's in this pull request?

Show an error message if the local time offset is bigger than `Network.TIME_OFFSET_MAX`.
It uses the timestamp received from the seed nodes.

The peer address gets casted to a string to check if it is in the `SEED_PEERS` array because `peerAddress.isSeed` and `SEED_PEERS.includes` always returned `false`. It seems like it creates new objects somewhere and doesn't use the original one.