### PR TITLE
Fix compilation error on Visual Studio

### DIFF
--- a/src/native/ed25519/fixedint.h
+++ b/src/native/ed25519/fixedint.h
@@ -4,7 +4,7 @@
     Not a compatible replacement for <stdint.h>, do not blindly use it as such.
 */
 
-#if ((defined(__STDC__) && __STDC__ && __STDC_VERSION__ >= 199901L) || (defined(__WATCOMC__) && (defined(_STDINT_H_INCLUDED) || __WATCOMC__ >= 1250)) || (defined(__GNUC__) && (defined(_STDINT_H) || defined(_STDINT_H_) || defined(__UINT_FAST64_TYPE__)) )) && !defined(FIXEDINT_H_INCLUDED)
+#if ((defined(__STDC__) && __STDC__ && __STDC_VERSION__ >= 199901L) || (defined(__WATCOMC__) && (defined(_STDINT_H_INCLUDED) || __WATCOMC__ >= 1250)) || (defined(__GNUC__) && (defined(_STDINT_H) || defined(_STDINT_H_) || defined(__UINT_FAST64_TYPE__))) || (defined(_MSC_VER) && (_MSC_VER >= 1600)) ) && !defined(FIXEDINT_H_INCLUDED)
     #include <stdint.h>
     #define FIXEDINT_H_INCLUDED
 


### PR DESCRIPTION
With the support for SHA512 we are also now importing `src/native/ed25519/fixedint.h` more than once, which shouldn't be a problem, but for some reason VS doesn't seem to be honoring the include guards in that file.

The purpose of the file is to `#include <stdint.h>` in platforms which support it (it was included in the C99 standard) and to define the (u)intN_t types manually in platforms which doesn't. According to [the interwebz](https://stackoverflow.com/questions/126279/c99-stdint-h-header-and-ms-visual-studio), `stdint.h` is missing from older VS versions, but [it was included in version 10](https://codeyarns.com/2010/04/13/visual-studio-2010-stdint-h/), and although there is at least [one report](https://github.com/jbboehr/msinttypes/issues/12) of it being missing on version 12, this seems to be an isolated issue.

So, this PR introduces a workaround by allowing `<sdtint.h>`  to be included in VS versions >= 10 instead of defined manually (this also probably means that VS < 10 will still have compilation issues if those versions don't honor the include guards, but I think those versions are old enough to be ignored safely).