### PR TITLE
Duplicate poolConfig in Sample

### DIFF
--- a/clients/nodejs/sample.conf
+++ b/clients/nodejs/sample.conf
@@ -83,7 +83,13 @@
         // Mining Pool Mode. In Smart Mode, the miner actively syncs with the network.
         // Possible values: "smart", "nano"
         // Default: "smart"
-        //mode: "smart"
+        //mode: "smart",
+        
+         // Optional data including stats about the device.
+        // The format of this JSON object is defined by the pool operator.
+        // Possible values: a valid JSON object
+        // Default: none
+        //deviceData: { deviceGroup: 'foobar' },
     },
 
     // Configure the JSON-RPC server.
@@ -204,33 +210,5 @@
         //{host: 'new-seed.nimiq.com', port: 8080, publicKey: 'e65e39616662f2c16d62dc08915e5a1d104619db8c2b9cf9b389f96c8dce9837'},
         //{host: 'nimiq-seed.company-network.int', port: 8080},
     ],
-
-    // Configure support for pool mining.
-    poolMining: {
-        // Enable pool mining support.
-        // Possible values: "no", "yes"
-        // Default "no"
-        //enabled: "yes",
-
-        // Hostname of the pool to mine for.
-        // Possible values: any fully-qualified domain name
-        // Default: none
-        //host: "pool.domain",
-
-        // Port of the pool to mine for.
-        // Possible values: any valid port number
-        // Default: none
-        //port: 8443,
-
-        // Pool mining mode. A smart miner has more verification capabilities than a nano miner.
-        // Possible values: "smart", "nano"
-        // Default: "smart"
-        //mode: "smart",
-
-        // Optional data including stats about the device.
-        // The format of this JSON object is defined by the pool operator.
-        // Possible values: a valid JSON object
-        // Default: none
-        //deviceData: { deviceGroup: 'foobar' },
-    },
+  
 }

--- a/clients/nodejs/sample.conf
+++ b/clients/nodejs/sample.conf
@@ -85,7 +85,7 @@
         // Default: "smart"
         //mode: "smart",
         
-         // Optional data including stats about the device.
+        // Optional data including stats about the device.
         // The format of this JSON object is defined by the pool operator.
         // Possible values: a valid JSON object
         // Default: none
@@ -210,5 +210,4 @@
         //{host: 'new-seed.nimiq.com', port: 8080, publicKey: 'e65e39616662f2c16d62dc08915e5a1d104619db8c2b9cf9b389f96c8dce9837'},
         //{host: 'nimiq-seed.company-network.int', port: 8080},
     ],
-  
 }


### PR DESCRIPTION
The config contained the configuration of the pool settings twice.

## Pull request checklist

- [ ] All tests pass. Demo project builds and runs.
- [ ] I have resolved any merge conflicts.

#### This fixes issue #___.

## What's in this pull request?

>...
