### PR TITLE
Fixed mempool transaction content display in rpc-client

### DIFF
--- a/clients/nodejs/remote.js
+++ b/clients/nodejs/remote.js
@@ -680,12 +680,12 @@ async function action(args, rl) {
             return;
         }
         case 'mempool.content': {
-            let includeTransactions = args.length === 2 && isTrue(args[1]);
+            const includeTransactions = args.length === 2 && isTrue(args[1]);
             const transactions = await jsonRpcFetch('mempoolContent', includeTransactions);
             console.log(chalk`Mempool content ({bold ${transactions.length}} transactions):`);
             for (const tx of transactions) {
                 if (includeTransactions) {
-                   console.log(chalk`ID: ${tx.hash} | ${tx.fromAddress} -> ${tx.toAddress} | ${nimValueFormat(tx.value, 10)} | ${nimValueFormat(tx.fee, 10)}`);
+                    console.log(chalk`ID: ${tx.hash} | ${tx.fromAddress} -> ${tx.toAddress} | ${nimValueFormat(tx.value, 10)} | ${nimValueFormat(tx.fee, 10)}`);
                 } else {
                     console.log(tx);
                 }
@@ -693,7 +693,7 @@ async function action(args, rl) {
             return;
         }
         case 'mempool.content.json': {
-            let includeTransactions = args.length === 2 && isTrue(args[1]);
+            const includeTransactions = args.length === 2 && isTrue(args[1]);
             console.log(JSON.stringify(await jsonRpcFetch('mempoolContent', includeTransactions)));
             return;
         }

--- a/clients/nodejs/remote.js
+++ b/clients/nodejs/remote.js
@@ -685,15 +685,7 @@ async function action(args, rl) {
             console.log(chalk`Mempool content ({bold ${transactions.length}} transactions):`);
             for (const tx of transactions) {
                 if (includeTransactions) {
-                    const date = new Date(tx.timestamp * 1000);
-                    let dateStr = date.getDate().toString();
-                    if (dateStr.length === 1) {
-                        dateStr = ` ${dateStr} `;
-                    } else {
-                        dateStr = `${dateStr[0]}${dateStr[1]} `;
-                    }
-                    console.log(chalk`${dateStr} | ${tx.fromString} -> ${tx.toString} | ${nimValueFormat(tx.value, 10)} | ${nimValueFormat(tx.fee, 10)}`);
-                    console.log(`ID: ${tx.hash}`);
+                   console.log(chalk`ID: ${tx.hash} | ${tx.fromAddress} -> ${tx.toAddress} | ${nimValueFormat(tx.value, 10)} | ${nimValueFormat(tx.fee, 10)}`);
                 } else {
                     console.log(tx);
                 }


### PR DESCRIPTION
## Pull request checklist

- [x] The RPC Client works as expected on my local machine.
- [x] I have resolved any merge conflicts.

## What's in this pull request?

* Fixed sender and receiver address display
* Removed timestamp display, since transactions in the mempool don't have a timestamp
