### PR TITLE
Fix some compile warnings of the native module

### DIFF
--- a/src/native/nimiq_native.c
+++ b/src/native/nimiq_native.c
@@ -105,7 +105,8 @@ int nimiq_argon2_no_wipe(void *out, const void *in, const size_t inlen, const ui
 }
 
 int nimiq_kdf(void *out, const void *in, const size_t inlen, const void* seed, const size_t seedlen, const uint32_t m_cost, const uint32_t iter) {
-    int ret, i;
+    int ret;
+    uint32_t i;
     ret = argon2d_hash_raw(1, m_cost == 0 ? NIMIQ_DEFAULT_ARGON2_COST : m_cost, 1, in, inlen, seed, seedlen, out, 32);
     if (ret != ARGON2_OK) return ret;
     for(i = 0; i < iter; ++i) {

--- a/src/native/nimiq_node.cc
+++ b/src/native/nimiq_node.cc
@@ -36,7 +36,7 @@ class MinerWorker : public AsyncWorker {
         void HandleOKCallback() {
             HandleScope scope;
             Local<Value> argv[] = {New<Number>(result_nonce)};
-            Nan::Call(*callback, 1, argv);
+            callback->Call(1, argv, async_resource);
         }
 
     private:
@@ -63,7 +63,7 @@ class Argon2Worker : public AsyncWorker {
         void HandleOKCallback() {
             HandleScope scope;
             Local<Value> argv[] = {New<Number>(res)};
-            Nan::Call(*callback, 1, argv);
+            callback->Call(1, argv, async_resource);
         }
 
     private:

--- a/src/native/nimiq_node.cc
+++ b/src/native/nimiq_node.cc
@@ -35,8 +35,8 @@ class MinerWorker : public AsyncWorker {
 
         void HandleOKCallback() {
             HandleScope scope;
-            Local<Value> argv[] = {New<Number>(result_nonce)}; 
-            callback->Call(1, argv);
+            Local<Value> argv[] = {New<Number>(result_nonce)};
+            Nan::Call(*callback, 1, argv);
         }
 
     private:
@@ -63,7 +63,7 @@ class Argon2Worker : public AsyncWorker {
         void HandleOKCallback() {
             HandleScope scope;
             Local<Value> argv[] = {New<Number>(res)};
-            callback->Call(1, argv);
+            Nan::Call(*callback, 1, argv);
         }
 
     private:


### PR DESCRIPTION
I get some annoying `node-gyp` warnings when executing `yarn`.
These fixes will make the (native) source compile with zero warnings on macOS!

_Changes:_
- Replaces the deprecated `Callback::Call()` with the newer `Nan::Call()` function.
- Fixes an integer type mismatch in `nimiq_kdf`

## Pull request checklist

- [x] All tests pass. Demo project builds and runs. (Codecov is bugged)
- [x] I have resolved any merge conflicts.
