### PR TITLE
Upgrade gcc version used by travis to 4.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,15 @@ env:
     # include $HOME/.local/bin for `aws`
     - PATH=$HOME/.local/bin:$PATH
     - CHROME_BIN=/usr/bin/google-chrome
+    - CC=gcc-4.9
+    - CXX=g++-4.9
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.9
 
 before_install:
 # set up awscli packages


### PR DESCRIPTION
GCC version 4.9 introduced support for AVX512 in the form of -mavx512f and other related flags. This commit allows Travis to correctly test #433 instead of failing in the building phase.