### PR TITLE
Automatic CPU feature detection and native module selection

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,45 +1,7 @@
 {
     "targets": [
         {
-            "target_name": "nimiq_node",
-            "sources": [
-                "src/native/argon2.c",
-                "src/native/blake2/blake2b.c",
-                "src/native/core.c",
-                "src/native/encoding.c",
-                "src/native/nimiq_native.c",
-                "src/native/opt.c",
-                "src/native/sha256.c",
-                "src/native/ed25519/collective.c",
-                "src/native/ed25519/fe.c",
-                "src/native/ed25519/ge.c",
-                "src/native/ed25519/keypair.c",
-                "src/native/ed25519/memory.c",
-                "src/native/ed25519/sc.c",
-                "src/native/ed25519/sha512.c",
-                "src/native/ed25519/sign.c",
-                "src/native/ed25519/verify.c",
-                "src/native/nimiq_node.cc"
-            ],
-            "defines": [
-                "ARGON2_NO_THREADS"
-            ],
-            "include_dirs": [
-                "<!(node -e \"require('nan')\")",
-                "src/native"
-            ],
-            "cflags_c": [
-                "-std=c99",
-                "-march=native"
-            ],
-            "xcode_settings": {
-                "OTHER_CFLAGS": [
-                    "-march=native"
-                ]
-            }
-        },
-        {
-            "target_name": "nimiq_node_generic",
+            "target_name": "nimiq_node_compat",
             "sources": [
                 "src/native/argon2.c",
                 "src/native/blake2/blake2b.c",
@@ -75,6 +37,140 @@
                     "-mtune=generic"
                 ]
             }
-        }
+        },
+        {
+            "target_name": "nimiq_node_sse2",
+            "sources": [
+                "src/native/argon2.c",
+                "src/native/blake2/blake2b.c",
+                "src/native/core.c",
+                "src/native/encoding.c",
+                "src/native/nimiq_native.c",
+                "src/native/opt.c",
+                "src/native/sha256.c",
+                "src/native/ed25519/collective.c",
+                "src/native/ed25519/fe.c",
+                "src/native/ed25519/ge.c",
+                "src/native/ed25519/keypair.c",
+                "src/native/ed25519/memory.c",
+                "src/native/ed25519/sc.c",
+                "src/native/ed25519/sha512.c",
+                "src/native/ed25519/sign.c",
+                "src/native/ed25519/verify.c",
+                "src/native/nimiq_node.cc"
+            ],
+            "defines": [
+                "ARGON2_NO_THREADS"
+            ],
+            "include_dirs": [
+                "<!(node -e \"require('nan')\")",
+                "src/native"
+            ],
+            "cflags_c": [
+                "-std=c99",
+                "-mtune=generic",
+                "-msse",
+                "-msse2"
+            ],
+            "xcode_settings": {
+                "OTHER_CFLAGS": [
+                    "-mtune=generic",
+                    "-msse",
+                    "-msse2"
+                ]
+            }
+        },
+        {
+            "target_name": "nimiq_node_avx2",
+            "sources": [
+                "src/native/argon2.c",
+                "src/native/blake2/blake2b.c",
+                "src/native/core.c",
+                "src/native/encoding.c",
+                "src/native/nimiq_native.c",
+                "src/native/opt.c",
+                "src/native/sha256.c",
+                "src/native/ed25519/collective.c",
+                "src/native/ed25519/fe.c",
+                "src/native/ed25519/ge.c",
+                "src/native/ed25519/keypair.c",
+                "src/native/ed25519/memory.c",
+                "src/native/ed25519/sc.c",
+                "src/native/ed25519/sha512.c",
+                "src/native/ed25519/sign.c",
+                "src/native/ed25519/verify.c",
+                "src/native/nimiq_node.cc"
+            ],
+            "defines": [
+                "ARGON2_NO_THREADS"
+            ],
+            "include_dirs": [
+                "<!(node -e \"require('nan')\")",
+                "src/native"
+            ],
+            "cflags_c": [
+                "-std=c99",
+                "-mtune=generic",
+                "-msse",
+                "-msse2",
+                "-mavx",
+                "-mavx2"
+            ],
+            "xcode_settings": {
+                "OTHER_CFLAGS": [
+                    "-mtune=generic",
+                    "-msse",
+                    "-msse2",
+                    "-mavx",
+                    "-mavx2"
+                ]
+            }
+        },
+        {
+            "target_name": "nimiq_node_avx512f",
+            "sources": [
+                "src/native/argon2.c",
+                "src/native/blake2/blake2b.c",
+                "src/native/core.c",
+                "src/native/encoding.c",
+                "src/native/nimiq_native.c",
+                "src/native/opt.c",
+                "src/native/sha256.c",
+                "src/native/ed25519/collective.c",
+                "src/native/ed25519/fe.c",
+                "src/native/ed25519/ge.c",
+                "src/native/ed25519/keypair.c",
+                "src/native/ed25519/memory.c",
+                "src/native/ed25519/sc.c",
+                "src/native/ed25519/sha512.c",
+                "src/native/ed25519/sign.c",
+                "src/native/ed25519/verify.c",
+                "src/native/nimiq_node.cc"
+            ],
+            "defines": [
+                "ARGON2_NO_THREADS"
+            ],
+            "include_dirs": [
+                "<!(node -e \"require('nan')\")",
+                "src/native"
+            ],
+            "cflags_c": [
+                "-std=c99",
+                "-msse",
+                "-msse2",
+                "-mavx",
+                "-mavx2",
+                "-mavx512f"
+            ],
+            "xcode_settings": {
+                "OTHER_CFLAGS": [
+                    "-msse",
+                    "-msse2",
+                    "-mavx",
+                    "-mavx2",
+                    "-mavx512f"
+                ]
+            }
+        },
     ]
 }

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "bindings": "^1.3.0",
     "btoa": "^1.1.2",
     "chalk": "^2.3.2",
+    "cpuid-git": "^0.3.0",
     "json5": "^1.0.1",
     "lodash.merge": "^4.6.1",
     "minimist": "^1.2.0",

--- a/src/main/generic/miner/MinerWorkerPool.js
+++ b/src/main/generic/miner/MinerWorkerPool.js
@@ -25,6 +25,8 @@ class MinerWorkerPool extends IWorker.Pool(MinerWorker) {
         this._superUpdateToSize = super._updateToSize;
 
         if (PlatformUtils.isNodeJs()) {
+            Log.i(MinerWorkerPool, 'Using native module: ' + cpuSupport);
+
             /**
              * @param {SerialBuffer} blockHeader
              * @param {number} compact

--- a/src/main/generic/miner/MinerWorkerPool.js
+++ b/src/main/generic/miner/MinerWorkerPool.js
@@ -25,7 +25,7 @@ class MinerWorkerPool extends IWorker.Pool(MinerWorker) {
         this._superUpdateToSize = super._updateToSize;
 
         if (PlatformUtils.isNodeJs()) {
-            Log.i(MinerWorkerPool, 'Using native module: ' + cpuSupport);
+            Log.i(MinerWorkerPool, `Using native module: ${cpuSupport}`);
 
             /**
              * @param {SerialBuffer} blockHeader

--- a/src/main/platform/nodejs/index.prefix.js
+++ b/src/main/platform/nodejs/index.prefix.js
@@ -6,7 +6,7 @@ const fs = require('fs');
 const dns = require('dns');
 const https = require('https');
 const http = require('http');
-const NodeNative = require('bindings')('nimiq_node.node');
+const cpuid = require('cpuid-git');
 const chalk = require('chalk');
 
 // Allow the user to specify the WebSocket engine through an environment variable. Default to ws
@@ -18,3 +18,26 @@ global.Class = {
         module.exports[clazz.prototype.constructor.name] = clazz;
     }
 };
+
+// Use CPUID to get the available processor extensions
+// and choose the right version of the nimiq_node native module
+const cpuSupport = function() {
+    try {
+        const c = cpuid();
+        const f = c.features;
+
+
+        if (f['avx512f'])
+            return "avx512f";
+        if (f['avx2'])
+            return "avx2";
+        if (f['sse2'])
+            return "sse2";
+        else
+            return "compat";
+    } catch (e) {
+        return "compat";
+    }
+}();
+
+const NodeNative = require('bindings')('nimiq_node_' + cpuSupport + '.node');

--- a/src/main/platform/nodejs/index.prefix.js
+++ b/src/main/platform/nodejs/index.prefix.js
@@ -23,21 +23,11 @@ global.Class = {
 // and choose the right version of the nimiq_node native module
 const cpuSupport = function() {
     try {
-        const c = cpuid();
-        const f = c.features;
-
-
-        if (f['avx512f'])
-            return "avx512f";
-        if (f['avx2'])
-            return "avx2";
-        if (f['sse2'])
-            return "sse2";
-        else
-            return "compat";
+        const cpu = cpuid();
+        return ['avx512f', 'avx2', 'sse2'].find(f => cpu.features[f]) || 'compat';
     } catch (e) {
-        return "compat";
+        return 'compat';
     }
 }();
 
-const NodeNative = require('bindings')('nimiq_node_' + cpuSupport + '.node');
+const NodeNative = require('bindings')(`nimiq_node_${cpuSupport}.node`);

--- a/travis-script.sh
+++ b/travis-script.sh
@@ -16,7 +16,6 @@ if [[ "$TO_TEST" == Karma/SauceLabs/* ]]; then export KARMA_BROWSERS="SL_$(basen
 if [[ "$TO_TEST" == Karma/Travis_CI/Chrome_* ]] && [ "$KARMA_BROWSERS" = "" ]; then export KARMA_BROWSERS=Travis_Chrome TO_TEST=Karma USE_ISTANBUL=1; fi
 if [[ "$TO_TEST" == Karma/Travis_CI/Firefox_* ]] && [ "$KARMA_BROWSERS" = "" ]; then export KARMA_BROWSERS=Firefox TO_TEST=Karma USE_ISTANBUL=1; fi
 if [[ "$TO_TEST" == Karma/Travis_CI/* ]] && [ "$KARMA_BROWSERS" = "" ]; then export KARMA_BROWSERS=Safari TO_TEST=Karma; fi
-cp build/Release/nimiq_node_generic.node build/Release/nimiq_node.node
 if [ "$TO_TEST" = "Karma" ]; then node_modules/.bin/karma start; fi
 if [ "$TO_TEST" = "NodeJS" ]; then export USE_ISTANBUL=1; node_modules/.bin/jasmine; fi
 if [ "$USE_ISTANBUL" = "1" ]; then node_modules/.bin/codecov; fi

--- a/yarn.lock
+++ b/yarn.lock
@@ -1890,6 +1890,12 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
+cpuid-git@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/cpuid-git/-/cpuid-git-0.3.0.tgz#69bdf60e7aab8e1043b9e77c728af9cf16291f88"
+  dependencies:
+    nan "^2.10.0"
+
 crc32-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/crc32-stream/-/crc32-stream-2.0.0.tgz#e3cdd3b4df3168dd74e3de3fbbcb7b297fe908f4"


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

#### Compile targets
This patch rewrites the way optimized nimiq_native modules are loaded.
The argon2d code currently has optimized implementations for SSE2, AVX2 and AVX512F.
Thus, `binding.gyp` was modified to compile four variants of nimiq_native:
- `compact`: that works on all CPUs
- `sse2`: works on most CPUs
- `avx2`: works on new CPUs
- `avx512f`: works on newest Intel processors (>=Skylake-SP)

#### Runtime detection
The client then has to choose between the four variants on runtime.
The `cpuid-git` package from npm is a native module that uses the `CPUID` instruction to detect available extensions.
This is done in `src/platform/nodejs/index.prefix.js`.
If the detection fails for some reason, the `compat` module is automatically selected.

Additionally, an info message is printed at the start of `MinerWorkerPool.js` showing which module is used, to assist miners.