### PR TITLE
Use gcc 4.9 in testing phase jobs too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,11 @@ jobs:
     - stage: test
       env: TO_TEST=Karma/SauceLabs/Edge_16
       addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.9
         sauce_connect:
           username: nimiq
         jwt:
@@ -87,8 +92,10 @@ jobs:
         apt:
           sources:
           - google-chrome
+          - ubuntu-toolchain-r-test
           packages:
           - google-chrome-stable
+          - g++-4.9
       script: ./travis-script.sh
     - stage: test
       env: TO_TEST=Karma/Travis_CI/Chrome_Stable USE_BABEL=1
@@ -96,8 +103,10 @@ jobs:
         apt:
           sources:
           - google-chrome
+          - ubuntu-toolchain-r-test
           packages:
           - google-chrome-stable
+          - g++-4.9
       script: ./travis-script.sh
     - stage: test
       env: TO_TEST=Karma/Travis_CI/Chrome_Beta
@@ -105,8 +114,10 @@ jobs:
         apt:
           sources:
           - google-chrome
+          - ubuntu-toolchain-r-test
           packages:
           - google-chrome-beta
+          - g++-4.9
       script: ./travis-script.sh
 #    - stage: test
 #      env: TO_TEST=Karma/SauceLabs/Chrome_Old
@@ -119,16 +130,31 @@ jobs:
     - stage: test
       env: TO_TEST=Karma/Travis_CI/Firefox_Stable
       addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.9
         firefox: latest
       script: ./travis-script.sh
     - stage: test
       env: TO_TEST=Karma/Travis_CI/Firefox_ESR
       addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.9
         firefox: latest-esr
       script: ./travis-script.sh
     - stage: test
       env: TO_TEST=Karma/Travis_CI/Firefox_Beta
       addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.9
         firefox: latest-beta
       script: ./travis-script.sh
 #    - stage: test


### PR DESCRIPTION
Currently Travis' tests for PRs from forked repositories fail on the testing phase as the jobs try to compile the dependencies with gcc/g++ version 4.9, but this version is not installed, because most testing jobs overwrite the global `addons` section (tests on branches and PRs directly on this repository are unaffected since they seem to use a precompiled cached version of `node_modules/` from S3, so they don't need to compile dependencies).

This PR makes sure that gcc/g++ version 4.9 is installed on testing jobs too.