### PR TITLE
Fix typo in consensus/base/block/Block.js

### DIFF
--- a/src/main/generic/consensus/base/block/Block.js
+++ b/src/main/generic/consensus/base/block/Block.js
@@ -242,7 +242,7 @@ class Block {
         }
         // Otherwise, if the prevHash doesn't match but the blocks should be adjacent according to their height fields,
         // this cannot be a valid successor of predecessor.
-        else if (this._header.height === predecessor.height.height + 1) {
+        else if (this._header.height === predecessor.header.height + 1) {
             Log.v(Block, 'No interlink successor - immediate height (2)');
             return false;
         }


### PR DESCRIPTION
In line 245, "predecessor.height.height" is a typo and should be
"predecessor.header.height".

## Pull request checklist

- [ ] All tests pass. Demo project builds and runs.
- [ ] I have resolved any merge conflicts.

## What's in this pull request?

[line 245 of Block.js](https://github.com/nimiq-network/core/blob/0ed21f7a94f9b745566933bbac12dcdcaa9e3ecc/src/main/generic/consensus/base/block/Block.js#L245) contains the following expression:
```javascript
else if (this._header.height === predecessor.height.height + 1)
// (should be header.height, as fixed in this PR)
```
which resolves to
```javascript
else if (this._header.height === undefined + 1)
```
which resolves to (2)
```javascript
else if (this._header.height === NaN)
```
so the check should always fail
```javascript
else if (false)
```

This could theoretically lead to wrong results when calling `Block.isInterlinkSuccessorOf((predecessor)`