### PR TITLE
WasmHelper: allow repeated calls to doImportBrowser

### DIFF
--- a/src/main/generic/utils/WasmHelper.js
+++ b/src/main/generic/utils/WasmHelper.js
@@ -7,17 +7,19 @@ class WasmHelper {
 
     static async doImportBrowser() {
         if (PlatformUtils.isNodeJs()) return;
-        if (WasmHelper._importStarted) {
-            Log.e(WasmHelper, 'doImportBrowser invoked twice');
-            return;
+        WasmHelper._importBrowserPromise = WasmHelper._importBrowserPromise || (async () => {
+            if (await WasmHelper.importWasmBrowser('worker-wasm.wasm')) {
+                await WasmHelper.importScriptBrowser('worker-wasm.js');
+            } else {
+                await WasmHelper.importScriptBrowser('worker-js.js');
+            }
+        })();
+        try {
+            await WasmHelper._importBrowserPromise;
+        } catch(e) {
+            WasmHelper._importBrowserPromise = null;
+            throw e;
         }
-        WasmHelper._importStarted = true;
-        if (await WasmHelper.importWasmBrowser('worker-wasm.wasm')) {
-            await WasmHelper.importScriptBrowser('worker-wasm.js');
-        } else {
-            await WasmHelper.importScriptBrowser('worker-js.js');
-        }
-        WasmHelper._importFinished = true;
     }
 
     static doImportNodeJs() {


### PR DESCRIPTION
- Don't warn on repeated calls to doImportBrowser.
- Ensure that subsequent calls resolve only after the wasm was actually imported.
- Remove unused property _importFinished

## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.
