### PR TITLE
Add conditional compilation of native addons

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 - [Core API Documentation](https://doc.esdoc.org/github.com/nimiq-network/core/): Documentation of the Nimiq Core library API.
 - [Node.js Client Documentation](doc/nodejs-client.md): Usage and configuration documentation for the Nimiq Node.js Client.
 - [JSON-RPC Client Documentation](doc/json-rpc-client.md): Usage instructions for the Nimiq JSON-RPC Client.
-- [Docker Documentation](doc/docker.md): Instuctions on setting up a Nimiq Node using Docker.
+- [Docker Documentation](doc/docker.md): Instructions on setting up a Nimiq Node using Docker.
+- [Packaging Documentation](doc/linux-packaging.md): Instructions on how to build binary packages for Linux (.deb and/or RPM) from this source code.
 
 ## Demo
 Check out our [Testnet](https://nimiq-testnet.com).
@@ -68,30 +69,6 @@ To run a Node.js client you will need a **publicly routable IP**, **Domain**, an
 
 ### Build
 Executing `yarn build` concatenates all sources into `dist/{web,web-babel,web-crypto,node}.js`
-
-### Build binary packages for Linux distributions
-
-After completing the [Quickstart](#quickstart), follow the steps below to build a Linux package. After the build process:
-- the package will be located in the `dist/` directory, 
-- once the package has been installed,
-    - a [configuration file](#run-node-js-client) will be located in `/etc/nimiq/nimiq.conf` and
-    - a `systemd` service will be avialable which you can manage with `systemctl start|stop|restart nimiq`. 
-
-#### Debian/Ubuntu (deb package format)
-
-1. Make sure you have `dpkg`, `jq` and `fakeroot` installed (otherwise, install with `apt`).
-2. Run `yarn run build-deb`.
-3. The deb package will be located in the `dist/` directory.
-
-Note: creating deb packages only works on Debian-based distributions and has been tested extensively on Ubuntu and Debian.
-
-#### Fedora/CentOS/RHEL (rpm package format)
-
-1. Make sure you have `rpm-build` installed (otherwise, install with `yum` or `dnf`).
-2. Run `yarn run build-rpm`.
-3. The rpm package will be located in the `dist/` directory.
-
-Note: creating rpm packages only works on rpm-based distributions and has been tested extensively on Fedora only.
 
 ## Contribute
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,44 +1,6 @@
 {
     "targets": [
         {
-            "target_name": "nimiq_node_compat",
-            "sources": [
-                "src/native/argon2.c",
-                "src/native/blake2/blake2b.c",
-                "src/native/core.c",
-                "src/native/encoding.c",
-                "src/native/nimiq_native.c",
-                "src/native/ref.c",
-                "src/native/sha256.c",
-                "src/native/ed25519/collective.c",
-                "src/native/ed25519/fe.c",
-                "src/native/ed25519/ge.c",
-                "src/native/ed25519/keypair.c",
-                "src/native/ed25519/memory.c",
-                "src/native/ed25519/sc.c",
-                "src/native/ed25519/sha512.c",
-                "src/native/ed25519/sign.c",
-                "src/native/ed25519/verify.c",
-                "src/native/nimiq_node.cc"
-            ],
-            "defines": [
-                "ARGON2_NO_THREADS"
-            ],
-            "include_dirs": [
-                "<!(node -e \"require('nan')\")",
-                "src/native"
-            ],
-            "cflags_c": [
-                "-std=c99",
-                "-mtune=generic"
-            ],
-            "xcode_settings": {
-                "OTHER_CFLAGS": [
-                    "-mtune=generic"
-                ]
-            }
-        },
-        {
             "target_name": "nimiq_node_native",
             "sources": [
                 "src/native/argon2.c",
@@ -76,141 +38,188 @@
                 ]
             }
         },
-        {
-            "target_name": "nimiq_node_avx",
-            "sources": [
-                "src/native/argon2.c",
-                "src/native/blake2/blake2b.c",
-                "src/native/core.c",
-                "src/native/encoding.c",
-                "src/native/nimiq_native.c",
-                "src/native/opt.c",
-                "src/native/sha256.c",
-                "src/native/ed25519/collective.c",
-                "src/native/ed25519/fe.c",
-                "src/native/ed25519/ge.c",
-                "src/native/ed25519/keypair.c",
-                "src/native/ed25519/memory.c",
-                "src/native/ed25519/sc.c",
-                "src/native/ed25519/sha512.c",
-                "src/native/ed25519/sign.c",
-                "src/native/ed25519/verify.c",
-                "src/native/nimiq_node.cc"
-            ],
-            "defines": [
-                "ARGON2_NO_THREADS"
-            ],
-            "include_dirs": [
-                "<!(node -e \"require('nan')\")",
-                "src/native"
-            ],
-            "cflags_c": [
-                "-std=c99",
-                "-mtune=generic",
-                "-msse",
-                "-msse2",
-                "-mavx"
-            ],
-            "xcode_settings": {
-                "OTHER_CFLAGS": [
-                    "-mtune=generic",
-                    "-msse",
-                    "-msse2",
-                    "-mavx"
-                ]
-            }
-        },
-        {
-            "target_name": "nimiq_node_avx2",
-            "sources": [
-                "src/native/argon2.c",
-                "src/native/blake2/blake2b.c",
-                "src/native/core.c",
-                "src/native/encoding.c",
-                "src/native/nimiq_native.c",
-                "src/native/opt.c",
-                "src/native/sha256.c",
-                "src/native/ed25519/collective.c",
-                "src/native/ed25519/fe.c",
-                "src/native/ed25519/ge.c",
-                "src/native/ed25519/keypair.c",
-                "src/native/ed25519/memory.c",
-                "src/native/ed25519/sc.c",
-                "src/native/ed25519/sha512.c",
-                "src/native/ed25519/sign.c",
-                "src/native/ed25519/verify.c",
-                "src/native/nimiq_node.cc"
-            ],
-            "defines": [
-                "ARGON2_NO_THREADS"
-            ],
-            "include_dirs": [
-                "<!(node -e \"require('nan')\")",
-                "src/native"
-            ],
-            "cflags_c": [
-                "-std=c99",
-                "-mtune=generic",
-                "-msse",
-                "-msse2",
-                "-mavx",
-                "-mavx2"
-            ],
-            "xcode_settings": {
-                "OTHER_CFLAGS": [
-                    "-mtune=generic",
-                    "-msse",
-                    "-msse2",
-                    "-mavx",
-                    "-mavx2"
-                ]
-            }
-        },
-        {
-            "target_name": "nimiq_node_avx512f",
-            "sources": [
-                "src/native/argon2.c",
-                "src/native/blake2/blake2b.c",
-                "src/native/core.c",
-                "src/native/encoding.c",
-                "src/native/nimiq_native.c",
-                "src/native/opt.c",
-                "src/native/sha256.c",
-                "src/native/ed25519/collective.c",
-                "src/native/ed25519/fe.c",
-                "src/native/ed25519/ge.c",
-                "src/native/ed25519/keypair.c",
-                "src/native/ed25519/memory.c",
-                "src/native/ed25519/sc.c",
-                "src/native/ed25519/sha512.c",
-                "src/native/ed25519/sign.c",
-                "src/native/ed25519/verify.c",
-                "src/native/nimiq_node.cc"
-            ],
-            "defines": [
-                "ARGON2_NO_THREADS"
-            ],
-            "include_dirs": [
-                "<!(node -e \"require('nan')\")",
-                "src/native"
-            ],
-            "cflags_c": [
-                "-std=c99",
-                "-msse",
-                "-msse2",
-                "-mavx",
-                "-mavx2",
-                "-mavx512f"
-            ],
-            "xcode_settings": {
-                "OTHER_CFLAGS": [
-                    "-msse",
-                    "-msse2",
-                    "-mavx",
-                    "-mavx2",
-                    "-mavx512f"
-                ]
-            }
-        },
-    ]
+    ],
+    "variables": {
+        "packaging": "<!(echo $PACKAGING)"
+    },
+    "conditions": [
+        ["packaging==1", {
+            "targets": [
+                {
+                    "target_name": "nimiq_node_compat",
+                    "sources": [
+                        "src/native/argon2.c",
+                        "src/native/blake2/blake2b.c",
+                        "src/native/core.c",
+                        "src/native/encoding.c",
+                        "src/native/nimiq_native.c",
+                        "src/native/ref.c",
+                        "src/native/sha256.c",
+                        "src/native/ed25519/collective.c",
+                        "src/native/ed25519/fe.c",
+                        "src/native/ed25519/ge.c",
+                        "src/native/ed25519/keypair.c",
+                        "src/native/ed25519/memory.c",
+                        "src/native/ed25519/sc.c",
+                        "src/native/ed25519/sha512.c",
+                        "src/native/ed25519/sign.c",
+                        "src/native/ed25519/verify.c",
+                        "src/native/nimiq_node.cc"
+                    ],
+                    "defines": [
+                        "ARGON2_NO_THREADS"
+                    ],
+                    "include_dirs": [
+                        "<!(node -e \"require('nan')\")",
+                        "src/native"
+                    ],
+                    "cflags_c": [
+                        "-std=c99",
+                        "-mtune=generic"
+                    ],
+                    "xcode_settings": {
+                        "OTHER_CFLAGS": [
+                            "-mtune=generic"
+                        ]
+                    }
+                },
+                {
+                    "target_name": "nimiq_node_avx",
+                    "sources": [
+                        "src/native/argon2.c",
+                        "src/native/blake2/blake2b.c",
+                        "src/native/core.c",
+                        "src/native/encoding.c",
+                        "src/native/nimiq_native.c",
+                        "src/native/opt.c",
+                        "src/native/sha256.c",
+                        "src/native/ed25519/collective.c",
+                        "src/native/ed25519/fe.c",
+                        "src/native/ed25519/ge.c",
+                        "src/native/ed25519/keypair.c",
+                        "src/native/ed25519/memory.c",
+                        "src/native/ed25519/sc.c",
+                        "src/native/ed25519/sha512.c",
+                        "src/native/ed25519/sign.c",
+                        "src/native/ed25519/verify.c",
+                        "src/native/nimiq_node.cc"
+                    ],
+                    "defines": [
+                        "ARGON2_NO_THREADS"
+                    ],
+                    "include_dirs": [
+                        "<!(node -e \"require('nan')\")",
+                        "src/native"
+                    ],
+                    "cflags_c": [
+                        "-std=c99",
+                        "-mtune=generic",
+                        "-msse",
+                        "-msse2",
+                        "-mavx"
+                    ],
+                    "xcode_settings": {
+                        "OTHER_CFLAGS": [
+                            "-mtune=generic",
+                            "-msse",
+                            "-msse2",
+                            "-mavx"
+                        ]
+                    }
+                },
+                {
+                    "target_name": "nimiq_node_avx2",
+                    "sources": [
+                        "src/native/argon2.c",
+                        "src/native/blake2/blake2b.c",
+                        "src/native/core.c",
+                        "src/native/encoding.c",
+                        "src/native/nimiq_native.c",
+                        "src/native/opt.c",
+                        "src/native/sha256.c",
+                        "src/native/ed25519/collective.c",
+                        "src/native/ed25519/fe.c",
+                        "src/native/ed25519/ge.c",
+                        "src/native/ed25519/keypair.c",
+                        "src/native/ed25519/memory.c",
+                        "src/native/ed25519/sc.c",
+                        "src/native/ed25519/sha512.c",
+                        "src/native/ed25519/sign.c",
+                        "src/native/ed25519/verify.c",
+                        "src/native/nimiq_node.cc"
+                    ],
+                    "defines": [
+                        "ARGON2_NO_THREADS"
+                    ],
+                    "include_dirs": [
+                        "<!(node -e \"require('nan')\")",
+                        "src/native"
+                    ],
+                    "cflags_c": [
+                        "-std=c99",
+                        "-mtune=generic",
+                        "-msse",
+                        "-msse2",
+                        "-mavx",
+                        "-mavx2"
+                    ],
+                    "xcode_settings": {
+                        "OTHER_CFLAGS": [
+                            "-mtune=generic",
+                            "-msse",
+                            "-msse2",
+                            "-mavx",
+                            "-mavx2"
+                        ]
+                    }
+                },
+                {
+                    "target_name": "nimiq_node_avx512f",
+                    "sources": [
+                        "src/native/argon2.c",
+                        "src/native/blake2/blake2b.c",
+                        "src/native/core.c",
+                        "src/native/encoding.c",
+                        "src/native/nimiq_native.c",
+                        "src/native/opt.c",
+                        "src/native/sha256.c",
+                        "src/native/ed25519/collective.c",
+                        "src/native/ed25519/fe.c",
+                        "src/native/ed25519/ge.c",
+                        "src/native/ed25519/keypair.c",
+                        "src/native/ed25519/memory.c",
+                        "src/native/ed25519/sc.c",
+                        "src/native/ed25519/sha512.c",
+                        "src/native/ed25519/sign.c",
+                        "src/native/ed25519/verify.c",
+                        "src/native/nimiq_node.cc"
+                    ],
+                    "defines": [
+                        "ARGON2_NO_THREADS"
+                    ],
+                    "include_dirs": [
+                        "<!(node -e \"require('nan')\")",
+                        "src/native"
+                    ],
+                    "cflags_c": [
+                        "-std=c99",
+                        "-msse",
+                        "-msse2",
+                        "-mavx",
+                        "-mavx2",
+                        "-mavx512f"
+                    ],
+                    "xcode_settings": {
+                        "OTHER_CFLAGS": [
+                            "-msse",
+                            "-msse2",
+                            "-mavx",
+                            "-mavx2",
+                            "-mavx512f"
+                        ]
+                    }
+                },
+            ]
+        }]
+    ],
 }

--- a/doc/linux-packaging.md
+++ b/doc/linux-packaging.md
@@ -1,0 +1,23 @@
+# Building binary packages for Linux
+
+## Pre-requisites
+
+Make sure you can build the `node.js` client from source code (i.e. you can successfully complete the Quickstart section of the `README` file). 
+
+#### Debian/Ubuntu (deb package format)
+
+1. Make sure you have `dpkg`, `jq` and `fakeroot` installed (otherwise, install them with `apt`).
+2. Run `PACKAGING=1 yarn`.
+3. Then run `yarn run build-deb`.
+4. The deb package will be located in the `dist/` directory.
+
+Note: creating deb packages only has been tested extensively on Ubuntu and Debian.
+
+#### Fedora/CentOS/RHEL (RPM package format)
+
+1. Make sure you have `rpm-build` installed (otherwise, install it with `yum` or `dnf`).
+2. Run `PACKAGING=1 yarn `
+3. Then run `yarn run build-rpm`.
+4. The RPM package will be located in the `dist/` directory.
+
+Note: creating RPM packages only has been tested extensively on Fedora.


### PR DESCRIPTION
Only compile the generic native addons when building the project for
packaging purposes.

Also, move the packaging documentation to the `doc` directory as it is
not relevant for the majority of users.