### PR TITLE
Add CRLF to the end of JSON-RPC responses

### DIFF
--- a/clients/nodejs/modules/JsonRpcServer.js
+++ b/clients/nodejs/modules/JsonRpcServer.js
@@ -870,10 +870,11 @@ class JsonRpcServer {
                 }
             }
             if (single && result.length === 1) {
-                res.end(JSON.stringify(result[0]));
+                res.write(JSON.stringify(result[0]));
             } else if (!single) {
-                res.end(JSON.stringify(result));
+                res.write(JSON.stringify(result));
             }
+            res.end("\r\n");
         });
     }
 }


### PR DESCRIPTION
Credit goes to @rraallvv !

## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

#### This fixes issue #451.

This PR just adds `\r\n` to the end of all JSON-RPC requests, making it more user-friendly to use on the terminal with `curl`.
