### PR TITLE
Add fromNetworkIdToNetworkName function to GenesisConfig class

### DIFF
--- a/src/main/generic/consensus/GenesisConfig.js
+++ b/src/main/generic/consensus/GenesisConfig.js
@@ -87,6 +87,22 @@ class GenesisConfig {
         if (!GenesisConfig._config) throw new Error('GenesisConfig not initialized');
         return GenesisConfig._config.SEED_LISTS;
     }
+
+    /**
+     * @param {number} NETWORK_ID
+     * @return {string}
+     */
+    static fromNetworkIdToNetworkName(NETWORK_ID) {
+        for (const key in Nimiq.GenesisConfig.CONFIGS) {
+            if (Nimiq.GenesisConfig.CONFIGS.hasOwnProperty(key)) {
+                const config = Nimiq.GenesisConfig.CONFIGS[key]
+                if(NETWORK_ID === config.NETWORK_ID)
+                    return config.NETWORK_NAME
+            }
+        }
+        throw new Error("Unable to find NETWORK_NAME based on given NETWORK_ID.")
+    }
+
 }
 Class.register(GenesisConfig);
 

--- a/src/main/generic/consensus/GenesisConfig.js
+++ b/src/main/generic/consensus/GenesisConfig.js
@@ -89,18 +89,17 @@ class GenesisConfig {
     }
 
     /**
-     * @param {number} NETWORK_ID
+     * @param {number} networkId
      * @return {string}
      */
-    static fromNetworkIdToNetworkName(NETWORK_ID) {
-        for (const key in GenesisConfig.CONFIGS) {
-            if (GenesisConfig.CONFIGS.hasOwnProperty(key)) {
-                const config = GenesisConfig.CONFIGS[key]
-                if(NETWORK_ID === config.NETWORK_ID)
-                    return config.NETWORK_NAME
+    static networkIdToNetworkName(networkId) {
+        for (const key of Object.keys(GenesisConfig.CONFIGS)) {
+            const config = GenesisConfig.CONFIGS[key];
+            if (networkId === config.NETWORK_ID) {
+                return config.NETWORK_NAME;
             }
         }
-        throw new Error("Unable to find NETWORK_NAME based on given NETWORK_ID.")
+        throw new Error(`Unable to find networkName for networkId ${networkId}`);
     }
 }
 Class.register(GenesisConfig);

--- a/src/main/generic/consensus/GenesisConfig.js
+++ b/src/main/generic/consensus/GenesisConfig.js
@@ -93,16 +93,15 @@ class GenesisConfig {
      * @return {string}
      */
     static fromNetworkIdToNetworkName(NETWORK_ID) {
-        for (const key in Nimiq.GenesisConfig.CONFIGS) {
-            if (Nimiq.GenesisConfig.CONFIGS.hasOwnProperty(key)) {
-                const config = Nimiq.GenesisConfig.CONFIGS[key]
+        for (const key in GenesisConfig.CONFIGS) {
+            if (GenesisConfig.CONFIGS.hasOwnProperty(key)) {
+                const config = GenesisConfig.CONFIGS[key]
                 if(NETWORK_ID === config.NETWORK_ID)
                     return config.NETWORK_NAME
             }
         }
         throw new Error("Unable to find NETWORK_NAME based on given NETWORK_ID.")
     }
-
 }
 Class.register(GenesisConfig);
 


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

#### This fixes issue #___.

## What's in this pull request?

> It's a static utility function that determines the NETWORK_NAME based on the given NETWORK_ID.  Throws a new error if a incorrect NETWORK_ID was provided.
