### PR TITLE
[WIP] Support ws pool protocol

### DIFF
--- a/clients/nodejs/index.js
+++ b/clients/nodejs/index.js
@@ -90,6 +90,10 @@ if ((isNano || config.poolMining.mode === 'nano') && config.uiServer.enabled) {
     console.error('The UI is currently not supported for nano clients');
     process.exit(1);
 }
+if (config.poolMining.enabled && config.poolMining.protocol !== 'ws' && config.poolMining.protocol !== 'wss') {
+    console.error(`Invalid pool protocol: ${config.poolMining.protocol}`);
+    process.exit(1);
+}
 if (!Nimiq.GenesisConfig.CONFIGS[config.network]) {
     console.error(`Invalid network name: ${config.network}`);
     process.exit(1);
@@ -242,12 +246,12 @@ const $ = {};
         }
         $.consensus.on('established', () => {
             if (!config.poolMining.enabled || !$.miner.isDisconnected()) return;
-            if (!config.poolMining.host || config.poolMining.port === -1) {
-                Nimiq.Log.i(TAG, 'Not connecting to pool as mining pool host or port were not specified.');
+            if (!config.poolMining.protocol || !config.poolMining.host || config.poolMining.port === -1) {
+                Nimiq.Log.i(TAG, 'Not connecting to pool as mining pool protocol, host or port were not specified.');
                 return;
             }
-            Nimiq.Log.i(TAG, `Connecting to pool ${config.poolMining.host} using device id ${deviceId} as a ${poolMode} client.`);
-            $.miner.connect(config.poolMining.host, config.poolMining.port);
+            Nimiq.Log.i(TAG, `Connecting to pool ${config.poolMining.protocol}://${config.poolMining.host} using device id ${deviceId} as a ${poolMode} client.`);
+            $.miner.connect(config.poolMining.protocol, config.poolMining.host, config.poolMining.port);
         });
     } else {
         $.miner = new Nimiq.Miner($.blockchain, $.accounts, $.mempool, $.network.time, $.wallet.address, extraData);

--- a/clients/nodejs/modules/Config.js
+++ b/clients/nodejs/modules/Config.js
@@ -49,6 +49,7 @@ const DEFAULT_CONFIG = /** @type {Config} */ {
     },
     poolMining: {
         enabled: false,
+        protocol: 'wss',
         host: null,
         port: -1,
         mode: 'smart',
@@ -117,6 +118,7 @@ const CONFIG_TYPES = {
     poolMining: {
         type: 'object', sub: {
             enabled: 'boolean',
+            protocol: 'string',
             host: 'string',
             port: 'number',
             mode: {type: 'string', values: ['smart', 'nano']},

--- a/clients/nodejs/sample.conf
+++ b/clients/nodejs/sample.conf
@@ -70,6 +70,13 @@
         // Default: "no"
         //enabled: "yes",
 
+        // Protocol of the mining pool server
+        // - "wss": Standard connection to pool.
+        // - "ws": Unencrypted connection, use only if the pool is in the same private network!
+        // Possible values: "wss", "ws"
+        // Default: "wss"
+        //protocol: "wss",
+
         // Hostname of the mining pool server
         // Possible values: any fully-qualified domain name.
         // Default: none
@@ -97,12 +104,12 @@
         // Start the JSON-RPC server.
         // Possible values: "no", "yes"
         // Default: "no"
-        //enabled: "yes",
+        enabled: "yes",
 
         // TCP-Port to use to create a listening socket for the JSON-RPC server.
         // Possible values: any valid port number
         // Default: 8648
-        //port: 8648,
+        port: 8648,
 
         // Allow Cross-Origin access to the JSON-RPC server from the specified origins. Use this option with caution.
         // Default: []

--- a/clients/nodejs/sample.conf
+++ b/clients/nodejs/sample.conf
@@ -104,12 +104,12 @@
         // Start the JSON-RPC server.
         // Possible values: "no", "yes"
         // Default: "no"
-        enabled: "yes",
+        //enabled: "yes",
 
         // TCP-Port to use to create a listening socket for the JSON-RPC server.
         // Possible values: any valid port number
         // Default: 8648
-        port: 8648,
+        //port: 8648,
 
         // Allow Cross-Origin access to the JSON-RPC server from the specified origins. Use this option with caution.
         // Default: []

--- a/src/main/generic/miner/BasePoolMiner.js
+++ b/src/main/generic/miner/BasePoolMiner.js
@@ -57,11 +57,12 @@ class BasePoolMiner extends Miner {
         }
     }
 
-    connect(host, port) {
+    connect(protocol, host, port) {
         if (this._ws) throw new Error('Call disconnect() first');
+        this._protocol = protocol;
         this._host = host;
         this._port = port;
-        const ws = this._ws = new WebSocket(`wss://${host}:${port}`);
+        const ws = this._ws = new WebSocket(`${protocol}://${host}:${port}`);
         this._ws.onopen = () => this._onOpen(ws);
         this._ws.onerror = (e) => this._onError(ws, e);
         this._ws.onmessage = (msg) => this._onMessage(ws, JSON.parse(msg.data));
@@ -114,7 +115,7 @@ class BasePoolMiner extends Miner {
         this.disconnect();
         this._reconnectTimeout = setTimeout(() => {
             if (!this._ws) {
-                this.connect(this._host, this._port);
+                this.connect(this._protocol, this._host, this._port);
             }
         }, this._exponentialBackoffReconnect);
         this._exponentialBackoffReconnect = Math.min(this._exponentialBackoffReconnect * 2, BasePoolMiner.RECONNECT_TIMEOUT_MAX);
@@ -233,6 +234,13 @@ class BasePoolMiner extends Miner {
      */
     isDisconnected() {
         return this.connectionState === BasePoolMiner.ConnectionState.CLOSED;
+    }
+
+    /**
+     * @type {string}
+     */
+    get protocol() {
+        return this._protocol;
     }
 
     /**


### PR DESCRIPTION
## Pull request checklist

- [ ] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

#### This fixes issue #459.

I think it's useful to have the ability to connect to a mining pool server over unencrypted WebSockets. In private mining networks (e.g. not routable over the public Internet), TLS encryption isn't needed or impossible.

## What's in this pull request?

* Added `poolMining.protocol` parameter in NodeJS client config.
* `BasePoolMiner::connect` method signature changed to `connect(protocol, host, port)`.

Problems to fix:
- [ ] Breaks dependent packages
- [ ] No way to set protocol from `JsonRpcServer` or command line flags
- [ ] Use `Protocol` class for `ws/wss` parameter instead of `string`?
- [ ] Include warning when using unencrypted `ws` over public Internet.