### PR TITLE
Build an ES6 module version of web.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -442,6 +442,23 @@ gulp.task('build-web', ['build-worker', 'create-version-file'], function () {
         .pipe(gulp.dest('dist'));
 });
 
+const BROWSER_MODULE_SOURCES = [
+    ...dependencies, // external dependencies
+    './src/main/platform/browser/module.prefix.js',
+    ...sources.platform.browser,
+    ...sources.generic,
+    './src/main/platform/browser/module.suffix.js'
+];
+
+gulp.task('build-web-module', ['build-worker', 'create-version-file'], function () {
+    return gulp.src(BROWSER_MODULE_SOURCES, {base: '.'})
+        .pipe(sourcemaps.init({loadMaps: true}))
+        .pipe(concat('web.esm.js'))
+        .pipe(uglify(uglify_config))
+        .pipe(sourcemaps.write('.'))
+        .pipe(gulp.dest('dist'));
+});
+
 const OFFLINE_SOURCES = [
     './src/main/platform/browser/index.prefix.js',
     ...sources.platform.offline,
@@ -449,7 +466,7 @@ const OFFLINE_SOURCES = [
     './src/main/platform/browser/index.suffix.js'
 ];
 
-gulp.task('build-offline-babel', ['create-version-file'], function () {
+gulp.task('build-offline-babel', ['build-worker', 'create-version-file'], function () {
     return merge(
         browserify([], {
             require: [
@@ -483,7 +500,7 @@ gulp.task('build-offline-babel', ['create-version-file'], function () {
         .pipe(gulp.dest('dist'));
 });
 
-gulp.task('build-offline', ['create-version-file'], function () {
+gulp.task('build-offline', ['build-worker', 'create-version-file'], function () {
     return gulp.src(OFFLINE_SOURCES, {base: '.'})
         .pipe(sourcemaps.init({loadMaps: true}))
         .pipe(concat('web-offline.js'))
@@ -587,6 +604,16 @@ gulp.task('eslint', function () {
         .pipe(eslint.failAfterError());
 });
 
-gulp.task('build', ['build-web', 'build-web-babel', 'build-web-istanbul', 'build-offline', 'build-offline-babel', 'build-loader', 'build-node', 'build-node-istanbul']);
+gulp.task('build', [
+    'build-web',
+    'build-web-babel',
+    'build-web-module',
+    'build-web-istanbul',
+    'build-offline',
+    'build-offline-babel',
+    'build-loader',
+    'build-node',
+    'build-node-istanbul'
+]);
 
 gulp.task('default', ['build']);

--- a/packaging/npm-publish.sh
+++ b/packaging/npm-publish.sh
@@ -21,6 +21,7 @@ $NIMIQ_VERSION
     "type": "git",
     "url": "https://github.com/nimiq-network/core.git"
   },
+  "main": "web.esm.js",
   "files": [
     "nimiq.js",
     "nimiq.js.map",
@@ -30,6 +31,8 @@ $NIMIQ_VERSION
     "web-babel.js.map",
     "web.js",
     "web.js.map",
+    "web.esm.js",
+    "web.esm.js.map",
     "web-offline.js",
     "web-offline.js.map",
     "worker.js",
@@ -41,7 +44,7 @@ $NIMIQ_VERSION
 }
 _EOF_
 
-cp ../dist/{nimiq.js,nimiq.js.map,VERSION,web-babel.js,web-babel.js.map,web.js,web.js.map,web-offline.js,web-offline.js.map,worker.js,worker-js.js,worker.js.map,worker-wasm.js,worker-wasm.wasm} npm/
+cp ../dist/{nimiq.js,nimiq.js.map,VERSION,web-babel.js,web-babel.js.map,web.js,web.js.map,web.esm.js,web.esm.js.map,web-offline.js,web-offline.js.map,worker.js,worker-js.js,worker.js.map,worker-wasm.js,worker-wasm.wasm} npm/
 cd npm
 
 echo "

--- a/packaging/npm/README.md
+++ b/packaging/npm/README.md
@@ -36,6 +36,12 @@ Just include the `nimiq.js` file from this package into your project:
 <script src="node_modules/@nimiq/core-web/nimiq.js"></script>
 ```
 
+or import it as an ES6 module:
+
+```
+import Nimiq from '@nimiq/core-web';
+```
+
 ## Contribute
 
 If you'd like to contribute to the development of Nimiq please follow our [Code of Conduct](/.github/CODE_OF_CONDUCT.md) and [Contributing Guidelines](/.github/CONTRIBUTING.md).

--- a/src/main/generic/utils/number/BigNumber.js
+++ b/src/main/generic/utils/number/BigNumber.js
@@ -2786,5 +2786,5 @@
     BigNumber['default'] = BigNumber.BigNumber = BigNumber;
     globalObject.BigNumber = BigNumber;
 })(Class.scope);
-BigNumber = Class.scope.BigNumber;
+const BigNumber = Class.scope.BigNumber;
 BigNumber.config({ DECIMAL_PLACES: 10 });

--- a/src/main/platform/browser/module.prefix.js
+++ b/src/main/platform/browser/module.prefix.js
@@ -1,0 +1,20 @@
+var exports = {};
+var Nimiq = exports;
+var Proxy; // ensure Proxy exists
+
+if (!Nimiq._currentScript) {
+    Nimiq._currentScript = document.currentScript;
+}
+if (!Nimiq._currentScript) {
+    // Heuristic
+    const scripts = document.getElementsByTagName('script');
+    Nimiq._currentScript = scripts[scripts.length - 1];
+}
+if (!Nimiq._path) {
+    if (Nimiq._currentScript && Nimiq._currentScript.src.indexOf('/') !== -1) {
+        Nimiq._path = Nimiq._currentScript.src.substring(0, Nimiq._currentScript.src.lastIndexOf('/') + 1);
+    } else {
+        // Fallback
+        Nimiq._path = './';
+    }
+}

--- a/src/main/platform/browser/module.suffix.js
+++ b/src/main/platform/browser/module.suffix.js
@@ -1,1 +1,10 @@
+/**
+ * @param {string} [path]
+ * @returns {Promise<void>}
+ */
+Nimiq.load = function(path) {
+    if (path) Nimiq._path = path;
+    return Nimiq.WasmHelper.doImportBrowser();
+}
+
 export default Nimiq;

--- a/src/main/platform/browser/module.suffix.js
+++ b/src/main/platform/browser/module.suffix.js
@@ -1,0 +1,1 @@
+export default Nimiq;


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

#### This fixes issue #406, #448.

## What's in this pull request?
This PR adds a new build target `web-module` that produces an ES6 module build at `web.esm.js`. A babelfied build is not provided, as any conversion should be handled by the downstream build-system.

The `package.json` of the `@nimiq/core-web` package is adapted to point to the new module file as the `main` entry point.

When released as the `@nimiq/core-web` package, a new version of the `@nimiq/core-types` package will be compatible and provide types.
