### PR TITLE
Limit amount of dust transactions

### DIFF
--- a/src/main/generic/consensus/base/mempool/Mempool.js
+++ b/src/main/generic/consensus/base/mempool/Mempool.js
@@ -64,6 +64,11 @@ class Mempool extends Observable {
             return Mempool.ReturnCode.INVALID;
         }
 
+        // Reject spam transactions
+        if (transaction.value <= Mempool.TRANSACTION_MIN_VALUE) {
+            return Mempool.ReturnCode.REJECTED;
+        }
+
         // Retrieve recipient account and test incoming transaction.
         /** @type {Account} */
         let recipientAccount;
@@ -432,6 +437,11 @@ class Mempool extends Observable {
 }
 
 /**
+ * Minimum value of transaction in Luna.
+ * @type {number}
+ */
+Mempool.TRANSACTION_MIN_VALUE = 1e5;
+/**
  * Fee threshold in sat/byte below which transactions are considered "free".
  * @type {number}
  */
@@ -454,6 +464,7 @@ Mempool.SIZE_MAX = 100000;
 
 /** @enum {number} */
 Mempool.ReturnCode = {
+    REJECTED: -3,
     FEE_TOO_LOW: -2,
     INVALID: -1,
 

--- a/src/main/generic/consensus/full/FullConsensusAgent.js
+++ b/src/main/generic/consensus/full/FullConsensusAgent.js
@@ -346,6 +346,10 @@ class FullConsensusAgent extends BaseConsensusAgent {
                 this.peer.channel.reject(Message.Type.TX, RejectMessage.Code.REJECT_INVALID, 'Invalid transaction',
                     transaction.hash().serialize());
                 return false;
+            case Mempool.ReturnCode.REJECTED:
+                this.peer.channel.reject(Message.Type.TX, RejectMessage.Code.REJECT_DUST, 'Rejected transaction',
+                    transaction.hash().serialize());
+                return false;
             default:
                 return false;
         }


### PR DESCRIPTION
## Pull request checklist

- [ ] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.
- [ ] Change logic to limit the amount of dust tx instead of banning them.

## What's in this pull request?

Recently, spammers have started to fill the chain with tiny transactions that only transfer `0.0001 NIM`, bloating the accounts tree and chain size. The attack has been going on for multiple days now. The worst example is [block 410757](https://nimiq.watch/#401757).

This pull request limits the minimum transaction amount to __1 NIM__. This is more than enough for genuine transactions.