### PR TITLE
BufferUtils: performance improvements by not copying Uint8Array views

### DIFF
--- a/src/main/generic/utils/buffer/BufferUtils.js
+++ b/src/main/generic/utils/buffer/BufferUtils.js
@@ -294,6 +294,7 @@ class BufferUtils {
     /**
      * @param {*} arrayLike
      * @return {Uint8Array}
+     * @private
      */
     static _toUint8View(arrayLike) {
         if (arrayLike instanceof Uint8Array) {

--- a/src/test/specs/generic/utils/buffer/BufferUtils.spec.js
+++ b/src/test/specs/generic/utils/buffer/BufferUtils.spec.js
@@ -120,12 +120,27 @@ describe('BufferUtils', () => {
         const buffer2 = BufferUtils.fromAscii('test');
         const buffer3 = BufferUtils.fromAscii('test false');
         const buffer4 = new Uint16Array(buffer3.buffer);
+        const buffer5 = BufferUtils.fromAscii('tess');
+        const buffer6 = [116, 101, 115, 115];
+        const buffer7 = BufferUtils.fromAscii('uest');
+        const buffer8 = [];
+        const buffer9 = BufferUtils.fromHex('e65e39616662f2c16d62dc08915e5a1d104619db8c2b9cf9b389f96c8dce9837');
+        const buffer10 = BufferUtils.fromHex('e65e39616662f2c16d62dc08915e5a1d104619db9c2b9cf9b389f96c8dce9837');
 
         expect(BufferUtils.equals(buffer1, buffer2)).toEqual(true);
         expect(BufferUtils.equals(buffer1, buffer3)).toEqual(false);
+        expect(BufferUtils.equals(buffer3, buffer1)).toEqual(false);
         expect(BufferUtils.equals(buffer3, buffer4)).toEqual(true);
+        expect(BufferUtils.equals(buffer2, buffer5)).toEqual(false);
+        expect(BufferUtils.equals(buffer5, buffer6)).toEqual(true);
+        expect(BufferUtils.equals(buffer1, buffer6)).toEqual(false);
+        expect(BufferUtils.equals(buffer1, buffer7)).toEqual(false);
+        expect(BufferUtils.equals(buffer8, buffer8)).toEqual(true);
+        expect(BufferUtils.equals(buffer8, buffer1)).toEqual(false);
+        expect(BufferUtils.equals(buffer1, buffer8)).toEqual(false);
+        expect(BufferUtils.equals(buffer9, buffer9)).toEqual(true);
+        expect(BufferUtils.equals(buffer9, buffer10)).toEqual(false);
     });
-
 
     it('can concat two buffers', () => {
         const buffer1 = BufferUtils.fromAscii('test1');

--- a/src/test/specs/generic/utils/buffer/BufferUtils.spec.js
+++ b/src/test/specs/generic/utils/buffer/BufferUtils.spec.js
@@ -119,9 +119,11 @@ describe('BufferUtils', () => {
         const buffer1 = BufferUtils.fromAscii('test');
         const buffer2 = BufferUtils.fromAscii('test');
         const buffer3 = BufferUtils.fromAscii('test false');
+        const buffer4 = new Uint16Array(buffer3.buffer);
 
         expect(BufferUtils.equals(buffer1, buffer2)).toEqual(true);
         expect(BufferUtils.equals(buffer1, buffer3)).toEqual(false);
+        expect(BufferUtils.equals(buffer3, buffer4)).toEqual(true);
     });
 
 


### PR DESCRIPTION
## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.

## What's in this pull request?

Performance improvements for several BufferUtils, most notably the `equals` methods, by using `Uint8Array` views on the underlying `BufferArray` data instead of copying the data as it was done up to now by `new Uint8Array(array);`.

Note that this also introduces a semantic change for `TypedArrays` other than `Uint8Array`, `Uint8ClampedArray` or `In8Array`:
```js
var data = new Uint16Array([1,2,259]);
var u8Copy = new Uint8Array(data); // [1, 2, 3]
var u8View = new Uint8Array(data.buffer); // [1, 0, 2, 0, 3, 1]
```

However, I would argue that this is the desired behaviour as copying does a modulo on the data, discarding information.
If on the other hand, the modulo was the intended effect of `new Uint8Array(array)`, I would just explicitly use the modulo operator and not copy the data.

Also the previous `equals` implementation was further flawed in my opinion due to the comparison on `.length` instead of `.byteLength` and the usage of `a.length` in the loop instead of `viewA.length`. By the current implementation the following are considered equal:

- `new Uint8Array([0]);`
- `new Uint16Array([0]);`
- `new Uint16Array([256]);`

The following were considered not equal, although one might argue that they are indeed equal:

- `new Uint8Array([0, 1, 2, 3]);`
- `new Uint16Array((new Uint8Array([0, 1, 2, 3])).buffer)`

With the updated implementation the following would still be considered equal though:

- `new Uint8Array([255])`
- `new Int8Array([-1])`
- `[511]`

Thus _maybe_ an additional check on the constructor should be done.