### PR TITLE
BufferUtils: fix use of native browser TextDecoder

### DIFF
--- a/src/main/generic/utils/buffer/BufferUtils.js
+++ b/src/main/generic/utils/buffer/BufferUtils.js
@@ -21,12 +21,13 @@ class BufferUtils {
 
     static _codePointTextDecoder(u8) {
         if (typeof TextDecoder === 'undefined') throw new Error('TextDecoder not supported');
-        if (BufferUtils._ISO_8859_15_DECODER === null) throw new Error('TextDecoder does not supprot iso-8859-15');
+        if (BufferUtils._ISO_8859_15_DECODER === null) throw new Error('TextDecoder does not support iso-8859-15');
         if (BufferUtils._ISO_8859_15_DECODER === undefined) {
             try {
                 BufferUtils._ISO_8859_15_DECODER = new TextDecoder('iso-8859-15');
-            } finally {
+            } catch (e) {
                 BufferUtils._ISO_8859_15_DECODER = null;
+                throw new Error('TextDecoder does not support iso-8859-15');
             }
         }
         return BufferUtils._ISO_8859_15_DECODER.decode(u8)


### PR DESCRIPTION
## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.

## What's in this pull request?

A fix for `_codePointTextDecoder` which currently does not work in the intended way. It always throws an exception and never returns a result:

- If `typeof TextDecoder === 'undefined' || BufferUtils._ISO_8859_15_DECODER === null` it throws by design.
- Otherwise, by using `finally`, `BufferUtils._ISO_8859_15_DECODER = null;` will be executed, resulting in an exception in `BufferUtils._ISO_8859_15_DECODER.decode(u8)`, calling `decode` on null.

As a result, `toBase64()` always uses the fallback implementation.

`_codePointTextDecoder` should thus be removed or fixed.