### PR TITLE
Fix crash when CPUID doesn't build

### DIFF
--- a/src/main/platform/nodejs/index.prefix.js
+++ b/src/main/platform/nodejs/index.prefix.js
@@ -6,7 +6,10 @@ const fs = require('fs');
 const dns = require('dns');
 const https = require('https');
 const http = require('http');
-const cpuid = require('cpuid-git');
+let cpuid;
+try {
+    cpuid = require('cpuid-git');
+} catch (e) {}
 const chalk = require('chalk');
 
 // Allow the user to specify the WebSocket engine through an environment variable. Default to ws


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

#### This fixes issue #475.

## What's in this pull request?

When `cpuid-git` doesn't build for some reason,
load the `native` or `compat` module instead of crashing.