### PR TITLE
Type adaptions and corrections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ jobs:
 #      osx_image: xcode8.3
 #      script: ./travis-script.sh
     - stage: test
-      env: TO_TEST=Karma/SauceLabs/Edge_16
+      env: TO_TEST=Karma/SauceLabs/Edge_18
       addons:
         apt:
           sources:

--- a/dist/namespace.d.ts
+++ b/dist/namespace.d.ts
@@ -1,4 +1,4 @@
-import * as _Nimiq from './';
+import * as _Nimiq from './types';
 
 export as namespace Nimiq;
-export = _Nimiq; 
+export = _Nimiq;

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -732,7 +732,7 @@ export class KeyPair extends Serializable {
         lockSalt?: Uint8Array,
     );
     public serialize(buf?: SerialBuffer): SerialBuffer;
-    public exportEncrypted(key: Uint8Array): Promise<Uint8Array>;
+    public exportEncrypted(key: Uint8Array): Promise<SerialBuffer>;
     public lock(key: string | Uint8Array): Promise<void>;
     public unlock(key: string | Uint8Array): Promise<void>;
     public relock(): void;
@@ -753,7 +753,7 @@ export class Secret extends Serializable {
     public encryptedSize: number;
     public type: Secret.Type;
     constructor(type: Secret.Type, purposeId: number);
-    public exportEncrypted(key: Uint8Array): Promise<Uint8Array>;
+    public exportEncrypted(key: Uint8Array): Promise<SerialBuffer>;
 }
 
 export namespace Secret {
@@ -3517,7 +3517,7 @@ export class Wallet {
     public createTransaction(recipient: Address, value: number, fee: number, validityStartHeight: number): BasicTransaction;
     public signTransaction(transaction: Transaction): SignatureProof;
     public exportPlain(): Uint8Array;
-    public exportEncrypted(key: Uint8Array|string): Promise<Uint8Array>;
+    public exportEncrypted(key: Uint8Array|string): Promise<SerialBuffer>;
     public lock(key: Uint8Array | string): Promise<void>;
     public relock(): void;
     public unlock(key: Uint8Array | string): Promise<void>;
@@ -3538,7 +3538,7 @@ export class MultiSigWallet extends Wallet {
         minSignatures: number,
         publicKeys: PublicKey[],
     );
-    public exportEncrypted(key: Uint8Array|string): Promise<Uint8Array>;
+    public exportEncrypted(key: Uint8Array|string): Promise<SerialBuffer>;
     public exportPlain(): Uint8Array;
     // @ts-ignore
     public createTransaction(recipientAddr: Address, value: number, fee: number, validityStartHeight: number): ExtendedTransaction;

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -2940,6 +2940,7 @@ export class GenesisConfig {
     public static dev(): void;
     public static bounty(): void;
     public static init(config: { NETWORK_ID: number, NETWORK_NAME: string, GENESIS_BLOCK: Block, GENESIS_ACCOUNTS: string, SEED_PEERS: PeerAddress[] }): void;
+    public static networkIdToNetworkName(networkId: number): string;
 }
 
 export class CloseType {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -104,6 +104,7 @@ module.exports = function (config) {
     sauceLabsConfig('Windows 10', 'MicrosoftEdge', '14.14393', 'Edge', '14');
     sauceLabsConfig('Windows 10', 'MicrosoftEdge', '15.15063', 'Edge', '15');
     sauceLabsConfig('Windows 10', 'MicrosoftEdge', '16.16299', 'Edge', '16');
+    sauceLabsConfig('Windows 10', 'MicrosoftEdge', '18.17763', 'Edge', '18');
 
     // Firefox
     for (const version of [48, 52, 55, 56]) sauceLabsConfig('Windows 10', 'firefox', `${version}.0`, 'Firefox', version);

--- a/src/main/generic/consensus/base/primitive/KeyPair.js
+++ b/src/main/generic/consensus/base/primitive/KeyPair.js
@@ -195,7 +195,7 @@ class KeyPair extends Serializable {
 
     /**
      * @param {Uint8Array} key
-     * @return {Promise.<Uint8Array>}
+     * @return {Promise.<SerialBuffer>}
      */
     exportEncrypted(key) {
         return this._privateKey.exportEncrypted(key);

--- a/src/main/generic/consensus/base/primitive/Secret.js
+++ b/src/main/generic/consensus/base/primitive/Secret.js
@@ -109,7 +109,7 @@ class Secret extends Serializable {
 
     /**
      * @param {Uint8Array} key
-     * @return {Promise.<Uint8Array>}
+     * @return {Promise.<SerialBuffer>}
      */
     async exportEncrypted(key) {
         const salt = new Uint8Array(Secret.ENCRYPTION_SALT_SIZE);

--- a/src/main/generic/wallet/MultiSigWallet.js
+++ b/src/main/generic/wallet/MultiSigWallet.js
@@ -110,7 +110,7 @@ class MultiSigWallet extends Wallet {
     /**
      * @override
      * @param {Uint8Array|string} key
-     * @return {Promise.<Uint8Array>}
+     * @return {Promise.<SerialBuffer>}
      */
     async exportEncrypted(key) {
         if (typeof key === 'string') key = BufferUtils.fromUtf8(key);

--- a/src/main/generic/wallet/Wallet.js
+++ b/src/main/generic/wallet/Wallet.js
@@ -75,7 +75,7 @@ class Wallet {
 
     /**
      * @param {Uint8Array|string} key
-     * @return {Promise.<Uint8Array>}
+     * @return {Promise.<SerialBuffer>}
      */
     exportEncrypted(key) {
         if (typeof key === 'string') key = BufferUtils.fromUtf8(key);


### PR DESCRIPTION
Add `GenesisConfig.networkIdToNetworkName()` method, correct return type of `.exportEncrypted()` methods, fix type namespace definition.