### PR TITLE
Fix namespace declaration file

### DIFF
--- a/dist/namespace.d.ts
+++ b/dist/namespace.d.ts
@@ -1,8 +1,8 @@
-import * as _Nimiq from './types';
-
-declare global {
-    namespace Nimiq {}
-}
+import _Nimiq from './types';
 
 export as namespace Nimiq;
 export = _Nimiq;
+
+declare global {
+    const Nimiq: typeof _Nimiq;
+}

--- a/dist/namespace.d.ts
+++ b/dist/namespace.d.ts
@@ -1,4 +1,8 @@
 import * as _Nimiq from './types';
 
+declare global {
+    namespace Nimiq {}
+}
+
 export as namespace Nimiq;
 export = _Nimiq;


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

This enables us to use @nimiq/core-web's namespace.d.ts file instead of @nimiq/core-types in typescript projects where not only types are used, like Accounts Manager.

## What's in this pull request?

Changed namespace.d.ts, which declares Nimiq as a constant (present when importing the core lib via CDN / script tag)
