### PR TITLE
Add volatile consensus options to NodeJS client

### DIFF
--- a/clients/nodejs/index.js
+++ b/clients/nodejs/index.js
@@ -59,6 +59,8 @@ if ((config.protocol === 'wss' && !(config.host && config.port && config.tls && 
         '                             seconds.\n' +
         '  --type=TYPE                Configure the consensus type to establish, one of\n' +
         '                             full (default), light, or nano.\n' +
+        '  --type=volatile-TYPE       Same as above, but in a non-persistent mode.\n' +
+        '                             The consensus state is kept in memory.\n' +
         '  --reverse-proxy[=PORT]     This client is behind a reverse proxy running on PORT,IP\n' +
         '                 [,IP]       (default: 8444,::ffff:127.0.0.1).\n' +
         '  --wallet-seed=SEED         Initialize wallet using SEED as a wallet seed.\n' +

--- a/clients/nodejs/index.js
+++ b/clients/nodejs/index.js
@@ -72,7 +72,7 @@ if ((config.protocol === 'wss' && !(config.host && config.port && config.tls && 
     process.exit();
 }
 
-const isNano = config.type === 'nano';
+const isNano = config.type === 'nano' || config.type === 'volatile-nano';
 
 if (isNano && config.miner.enabled) {
     console.error('Cannot mine when running as a nano client');
@@ -106,7 +106,7 @@ if (config.reverseProxy.enabled && config.protocol === 'dumb') {
     console.error('Cannot run a dumb client behind a reverse proxy');
     process.exit(1);
 }
-if (config.type === 'light') {
+if (config.type === 'light' || config.type === 'volatile-light') {
     console.error('Light node type is temporarily disabled');
     process.exit(1);
 }
@@ -184,6 +184,15 @@ const $ = {};
             break;
         case 'nano':
             $.consensus = await Nimiq.Consensus.nano(networkConfig);
+            break;
+        case 'volatile-full':
+            $.consensus = await Nimiq.Consensus.volatileFull(networkConfig);
+            break;
+        case 'volatile-light':
+            $.consensus = await Nimiq.Consensus.volatileLight(networkConfig);
+            break;
+        case 'volatile-nano':
+            $.consensus = await Nimiq.Consensus.volatileNano(networkConfig);
             break;
     }
 

--- a/clients/nodejs/index.js
+++ b/clients/nodejs/index.js
@@ -59,8 +59,8 @@ if ((config.protocol === 'wss' && !(config.host && config.port && config.tls && 
         '                             seconds.\n' +
         '  --type=TYPE                Configure the consensus type to establish, one of\n' +
         '                             full (default), light, or nano.\n' +
-        '  --volatile                 Run in a non-persistent mode.\n' +
-        '                             The consensus state is kept in memory.\n' +
+        '  --volatile                 Run in volatile mode. Consensus state is kept\n' +
+        '                             in memory only and not written to disk.\n' +
         '  --reverse-proxy[=PORT]     This client is behind a reverse proxy running on PORT,IP\n' +
         '                 [,IP]       (default: 8444,::ffff:127.0.0.1).\n' +
         '  --wallet-seed=SEED         Initialize wallet using SEED as a wallet seed.\n' +

--- a/clients/nodejs/modules/Config.js
+++ b/clients/nodejs/modules/Config.js
@@ -12,6 +12,7 @@ const TAG = 'Config';
  * @property {string} protocol
  * @property {boolean} dumb
  * @property {string} type
+ * @property {boolean} volatile
  * @property {string} network
  * @property {boolean} passive
  * @property {number} statistics
@@ -37,6 +38,7 @@ const DEFAULT_CONFIG = /** @type {Config} */ {
     protocol: 'wss',
     dumb: false, // deprecated
     type: 'full',
+    volatile: false,
     network: 'main',
     passive: false,
     statistics: 0,
@@ -101,7 +103,8 @@ const CONFIG_TYPES = {
     port: 'number',
     protocol: {type: 'string', values: ['wss', 'ws', 'dumb']},
     dumb: 'boolean', // deprecated
-    type: {type: 'string', values: ['full', 'light', 'nano', 'volatile-full', 'volatile-light', 'volatile-nano']},
+    type: {type: 'string', values: ['full', 'light', 'nano']},
+    volatile: 'boolean',
     network: 'string',
     passive: 'boolean',
     statistics: 'number',
@@ -308,6 +311,7 @@ function readFromArgs(argv, config = merge({}, DEFAULT_CONFIG)) {
     if (typeof argv.protocol === 'string') config.protocol = argv.protocol;
     if (argv.dumb) config.dumb = argv.dumb; // deprecated
     if (typeof argv.type === 'string') config.type = argv.type;
+    if (argv.volatile) config.volatile = argv.volatile;
     if (typeof argv.network === 'string') config.network = argv.network;
     if (argv.passive) config.passive = true;
     if (argv.statistics) {

--- a/clients/nodejs/modules/Config.js
+++ b/clients/nodejs/modules/Config.js
@@ -101,7 +101,7 @@ const CONFIG_TYPES = {
     port: 'number',
     protocol: {type: 'string', values: ['wss', 'ws', 'dumb']},
     dumb: 'boolean', // deprecated
-    type: {type: 'string', values: ['full', 'light', 'nano']},
+    type: {type: 'string', values: ['full', 'light', 'nano', 'volatile-full', 'volatile-light', 'volatile-nano']},
     network: 'string',
     passive: 'boolean',
     statistics: 'number',

--- a/clients/nodejs/sample.conf
+++ b/clients/nodejs/sample.conf
@@ -25,9 +25,14 @@
     //protocol: "wss",
 
     // Specify the type of node to run.
-    // Possible values: ("volatile-") "full", "light", "nano"
+    // Possible values: "full", "light", "nano"
     // Default: "full"
     //type: "full",
+
+    // Run in volatile mode: do not write consensus data to the file system.
+    // Possible values: "no", "yes"
+    // Default: "no"
+    //volatile: "yes",
 
     // Specify the network to connect to.
     // Possible values: "main", "test", "dev"

--- a/clients/nodejs/sample.conf
+++ b/clients/nodejs/sample.conf
@@ -29,7 +29,7 @@
     // Default: "full"
     //type: "full",
 
-    // Run in volatile mode: do not write consensus data to the file system.
+    // Run in volatile mode: do not write consensus state to disk.
     // Possible values: "no", "yes"
     // Default: "no"
     //volatile: "yes",

--- a/clients/nodejs/sample.conf
+++ b/clients/nodejs/sample.conf
@@ -25,7 +25,7 @@
     //protocol: "wss",
 
     // Specify the type of node to run.
-    // Possible values: "full", "light", "nano"
+    // Possible values: ("volatile-") "full", "light", "nano"
     // Default: "full"
     //type: "full",
 


### PR DESCRIPTION
~~Adds `volatile-full`, `volatile-light` and `volatile-nano` consensus options to config.~~

Adds a flag for running in `--volatile` mode