### PR TITLE
Fix request ID bug in JsonRpcServer

### DIFF
--- a/clients/nodejs/modules/JsonRpcServer.js
+++ b/clients/nodejs/modules/JsonRpcServer.js
@@ -857,7 +857,7 @@ class JsonRpcServer {
                 }
                 try {
                     const methodRes = await this._methods.get(msg.method).apply(null, msg.params instanceof Array ? msg.params : [msg.params]);
-                    if (msg.id) {
+                    if (Number.isInteger(msg.id)) {
                         result.push({'jsonrpc': '2.0', 'result': methodRes, 'id': msg.id});
                     }
                 } catch (e) {

--- a/clients/nodejs/modules/JsonRpcServer.js
+++ b/clients/nodejs/modules/JsonRpcServer.js
@@ -857,7 +857,7 @@ class JsonRpcServer {
                 }
                 try {
                     const methodRes = await this._methods.get(msg.method).apply(null, msg.params instanceof Array ? msg.params : [msg.params]);
-                    if (Number.isInteger(msg.id)) {
+                    if (typeof msg.id === 'string' || Number.isInteger(msg.id)) {
                         result.push({'jsonrpc': '2.0', 'result': methodRes, 'id': msg.id});
                     }
                 } catch (e) {


### PR DESCRIPTION
## Bug

The server can't handle requests with ID `0`.
A request like `{"method":"getTransactionsByAddress","params":["NQ58 10J7 QBX2 G31A 5MMK BPYU SYXT A96U 5KJ1"],"id":0,"jsonrpc":"2.0"}` causes an empty response which can potentially cause headaches.

This makes the server incompatible with [some libraries](https://github.com/ybbus/jsonrpc) that send a `0` request ID by default (and probably violates the RFC).

## Fix

Check for `Number.isInteger(request.id)` instead of `!!request.id`.